### PR TITLE
feat(FR #7): Integrate LLM API for AI moves

### DIFF
--- a/src/api/battleClient.ts
+++ b/src/api/battleClient.ts
@@ -1,0 +1,70 @@
+/** Battle API client - calls /api/battle for AI move selection */
+
+import type { BattleState } from "../types/game";
+
+interface BattleAPIRequest {
+  mechPrompt: string;
+  gameState: {
+    playerHP: number;
+    opponentHP: number;
+    lastMove: string;
+    statusEffects: string[];
+  };
+}
+
+interface BattleAPIResponse {
+  move: 0 | 1 | 2 | 3;
+  reasoning?: string;
+}
+
+const MAX_RETRIES = 2;
+
+function buildRequestBody(
+  prompt: string,
+  state: BattleState,
+): BattleAPIRequest {
+  const lastLog = state.log.filter((l) => l.includes("used")).pop() ?? "";
+  return {
+    mechPrompt: prompt,
+    gameState: {
+      playerHP: state.player.hp,
+      opponentHP: state.opponent.hp,
+      lastMove: lastLog,
+      statusEffects: [],
+    },
+  };
+}
+
+/**
+ * Call the battle API to get an AI move.
+ * Retries up to 2 times on failure. Returns null if all attempts fail.
+ */
+export async function callBattleAPI(
+  prompt: string,
+  gameState: BattleState,
+): Promise<BattleAPIResponse | null> {
+  const body = buildRequestBody(prompt, gameState);
+
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      const res = await fetch("/api/battle", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        continue;
+      }
+
+      const data = (await res.json()) as BattleAPIResponse;
+      if (typeof data.move === "number" && data.move >= 0 && data.move <= 3) {
+        return data;
+      }
+    } catch {
+      // Network error — retry
+    }
+  }
+
+  return null;
+}

--- a/src/scenes/BattleScene.ts
+++ b/src/scenes/BattleScene.ts
@@ -3,6 +3,7 @@
  */
 
 import Phaser from "phaser";
+import { callBattleAPI } from "../api/battleClient";
 import { type Mech, MechType, TurnPhase } from "../types/game";
 import { BattleManager } from "../utils/BattleManager";
 
@@ -60,7 +61,11 @@ const OPPONENT_MECH: Mech = {
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 const LOG_MAX_LINES = 5;
 const HP_TWEEN_DURATION = 500;
-const AI_THINK_DELAY = 1000;
+
+const PROMPT_STORAGE_KEY = "mechArena_battlePrompt";
+const PROMPT_MAX_LENGTH = 500;
+const PROMPT_PLACEHOLDER =
+  "Enter your mech's battle strategy... e.g. 'Be aggressive, use high-damage attacks when HP is high. Switch to defense when low.'";
 
 export class BattleScene extends Phaser.Scene {
   // Battle state
@@ -99,6 +104,10 @@ export class BattleScene extends Phaser.Scene {
   // Result overlay
   private resultOverlay?: Phaser.GameObjects.Container;
 
+  // Prompt UI (DOM elements)
+  private promptContainer?: HTMLDivElement;
+  private mechPrompt = "";
+
   constructor() {
     super({ key: "BattleScene" });
   }
@@ -114,8 +123,12 @@ export class BattleScene extends Phaser.Scene {
     this.displayedPlayerRatio = 1;
     this.isAnimating = false;
 
+    // Load saved prompt from localStorage
+    this.mechPrompt = localStorage.getItem(PROMPT_STORAGE_KEY) ?? "";
+
     const { width, height } = this.scale;
     this.buildUI(width, height);
+    this.createPromptUI();
 
     // Sync initial log
     const state = this.battleManager.getState();
@@ -426,6 +439,62 @@ export class BattleScene extends Phaser.Scene {
     }
   }
 
+  // --- Prompt UI (DOM overlay) ---
+
+  private createPromptUI(): void {
+    // Remove existing if rebuilding
+    if (this.promptContainer) {
+      this.promptContainer.remove();
+    }
+
+    const container = document.createElement("div");
+    container.style.cssText =
+      "position:fixed;bottom:8px;left:8px;z-index:100;display:flex;flex-direction:column;gap:4px;width:220px;";
+
+    const textarea = document.createElement("textarea");
+    textarea.maxLength = PROMPT_MAX_LENGTH;
+    textarea.placeholder = PROMPT_PLACEHOLDER;
+    textarea.value = this.mechPrompt;
+    textarea.style.cssText =
+      "width:100%;height:60px;background:#222;color:#0f8;border:1px solid #444;border-radius:6px;padding:6px;font-size:12px;resize:none;font-family:monospace;";
+
+    const row = document.createElement("div");
+    row.style.cssText =
+      "display:flex;justify-content:space-between;align-items:center;";
+
+    const counter = document.createElement("span");
+    counter.style.cssText = "color:#666;font-size:11px;font-family:monospace;";
+    counter.textContent = `${this.mechPrompt.length}/${PROMPT_MAX_LENGTH}`;
+
+    const saveBtn = document.createElement("button");
+    saveBtn.textContent = "Save";
+    saveBtn.style.cssText =
+      "background:#0f8;color:#000;border:none;border-radius:4px;padding:4px 12px;font-size:12px;font-weight:bold;cursor:pointer;font-family:monospace;";
+
+    textarea.addEventListener("input", () => {
+      this.mechPrompt = textarea.value;
+      counter.textContent = `${textarea.value.length}/${PROMPT_MAX_LENGTH}`;
+    });
+
+    saveBtn.addEventListener("click", () => {
+      localStorage.setItem(PROMPT_STORAGE_KEY, this.mechPrompt);
+      saveBtn.textContent = "Saved!";
+      saveBtn.style.background = "#0a5";
+      setTimeout(() => {
+        saveBtn.textContent = "Save";
+        saveBtn.style.background = "#0f8";
+      }, 1000);
+    });
+
+    row.appendChild(counter);
+    row.appendChild(saveBtn);
+    container.appendChild(textarea);
+    container.appendChild(row);
+
+    document.body.appendChild(container);
+    this.promptContainer = container;
+  }
+
   // --- Skill buttons (2x2 grid) ---
 
   private createSkillButtons(w: number, h: number): void {
@@ -652,12 +721,6 @@ export class BattleScene extends Phaser.Scene {
     });
   }
 
-  private delay(ms: number): Promise<void> {
-    return new Promise((resolve) => {
-      this.time.delayedCall(ms, () => resolve());
-    });
-  }
-
   // --- Turn execution ---
 
   private async onSkillSelected(index: number): Promise<void> {
@@ -669,84 +732,80 @@ export class BattleScene extends Phaser.Scene {
     this.setButtonsEnabled(false);
 
     const prevOpponentHp = state.opponent.hp;
-    const prevPlayerHp = state.player.hp;
     const prevLogLen = state.log.length;
 
-    // Execute full turn in state machine
-    const newState = this.battleManager.executeTurn(index);
-    const newLogs = newState.log.slice(prevLogLen);
-
-    // Split logs into player-attack and AI-attack phases
-    let aiLogStart = newLogs.length;
-    for (let i = 0; i < newLogs.length; i++) {
-      if (newLogs[i].includes(`${newState.opponent.name} used`)) {
-        aiLogStart = i;
-        break;
-      }
-    }
-    const playerLogs = newLogs.slice(0, aiLogStart);
-    const aiLogs = newLogs.slice(aiLogStart);
-
     // --- Phase 1: Player attack ---
-    this.setTurnIndicator(TurnPhase.PlayerTurn);
+    const afterPlayer = this.battleManager.executePlayerAttack(index);
+    const playerLogs = afterPlayer.log.slice(prevLogLen);
 
+    this.setTurnIndicator(TurnPhase.PlayerTurn);
     for (const msg of playerLogs) {
       this.addLogMessage(msg);
     }
 
     await this.playAttackAnimation(true);
 
-    const opponentDamaged = newState.opponent.hp < prevOpponentHp;
-    if (opponentDamaged) {
+    if (afterPlayer.opponent.hp < prevOpponentHp) {
       await this.playDamageFlash(true);
     }
 
     await this.animateHP(
       true,
-      newState.opponent.hp / newState.opponent.maxHp,
-      newState.opponent.hp,
-      newState.opponent.maxHp,
+      afterPlayer.opponent.hp / afterPlayer.opponent.maxHp,
+      afterPlayer.opponent.hp,
+      afterPlayer.opponent.maxHp,
     );
 
     // Check if opponent defeated
-    if (newState.winner === "player") {
-      for (const msg of aiLogs) {
-        this.addLogMessage(msg);
-      }
+    if (afterPlayer.winner === "player") {
       this.setTurnIndicator(TurnPhase.BattleOver);
       this.showResultScreen(true);
       return;
     }
 
-    // --- Phase 2: AI thinking ---
+    // --- Phase 2: AI thinking + API call ---
     this.setTurnIndicator(TurnPhase.AiThinking);
     this.showSpinner();
-    await this.delay(AI_THINK_DELAY);
+
+    let aiSkillIndex: number;
+    if (this.mechPrompt.trim()) {
+      const apiResult = await callBattleAPI(
+        this.mechPrompt,
+        this.battleManager.getState(),
+      );
+      aiSkillIndex = apiResult?.move ?? this.battleManager.getRandomAiSkill();
+    } else {
+      aiSkillIndex = this.battleManager.getRandomAiSkill();
+    }
+
     this.hideSpinner();
 
     // --- Phase 3: AI attack ---
-    this.setTurnIndicator(TurnPhase.AiTurn);
+    const prevPlayerHp = afterPlayer.player.hp;
+    const aiLogLen = this.battleManager.getState().log.length;
+    const afterAi = this.battleManager.executeAiAttack(aiSkillIndex);
+    const aiLogs = afterAi.log.slice(aiLogLen);
 
+    this.setTurnIndicator(TurnPhase.AiTurn);
     for (const msg of aiLogs) {
       this.addLogMessage(msg);
     }
 
     await this.playAttackAnimation(false);
 
-    const playerDamaged = newState.player.hp < prevPlayerHp;
-    if (playerDamaged) {
+    if (afterAi.player.hp < prevPlayerHp) {
       await this.playDamageFlash(false);
     }
 
     await this.animateHP(
       false,
-      newState.player.hp / newState.player.maxHp,
-      newState.player.hp,
-      newState.player.maxHp,
+      afterAi.player.hp / afterAi.player.maxHp,
+      afterAi.player.hp,
+      afterAi.player.maxHp,
     );
 
     // Check if player defeated
-    if (newState.winner === "opponent") {
+    if (afterAi.winner === "opponent") {
       this.setTurnIndicator(TurnPhase.BattleOver);
       this.showResultScreen(false);
       return;

--- a/src/utils/BattleManager.ts
+++ b/src/utils/BattleManager.ts
@@ -39,14 +39,13 @@ export class BattleManager {
     return this.getState();
   }
 
-  /** Execute a full turn: player skill → check → AI skill → check */
-  executeTurn(skillIndex: number): BattleState {
+  /** Execute player's attack phase. Returns state after player attack + win check. */
+  executePlayerAttack(skillIndex: number): BattleState {
     if (this.state.phase !== TurnPhase.PlayerTurn) return this.getState();
     if (skillIndex < 0 || skillIndex >= this.state.player.skills.length) {
       return this.getState();
     }
 
-    // Player attacks
     const playerSkill = this.state.player.skills[skillIndex];
     const playerDmg = this.calculateDamage(
       playerSkill,
@@ -56,16 +55,23 @@ export class BattleManager {
     this.addLog(`${this.state.player.name} used ${playerSkill.name}!`);
     this.updateHP("opponent", playerDmg);
 
-    // Check win after player attack
     this.state.phase = TurnPhase.CheckWin;
     if (this.checkWin()) return this.getState();
 
-    // AI thinking → AI turn
     this.state.phase = TurnPhase.AiThinking;
-    const aiSkillIndex = this.selectAiSkill();
-    this.state.phase = TurnPhase.AiTurn;
+    return this.getState();
+  }
 
-    const aiSkill = this.state.opponent.skills[aiSkillIndex];
+  /** Execute AI's attack phase with given skill index. */
+  executeAiAttack(aiSkillIndex: number): BattleState {
+    if (this.state.phase !== TurnPhase.AiThinking) return this.getState();
+    const clampedIndex = Math.max(
+      0,
+      Math.min(aiSkillIndex, this.state.opponent.skills.length - 1),
+    );
+
+    this.state.phase = TurnPhase.AiTurn;
+    const aiSkill = this.state.opponent.skills[clampedIndex];
     const aiDmg = this.calculateDamage(
       aiSkill,
       this.state.opponent,
@@ -74,14 +80,17 @@ export class BattleManager {
     this.addLog(`${this.state.opponent.name} used ${aiSkill.name}!`);
     this.updateHP("player", aiDmg);
 
-    // Check win after AI attack
     this.state.phase = TurnPhase.CheckWin;
     if (this.checkWin()) return this.getState();
 
-    // Next turn
     this.state.turnCount++;
     this.state.phase = TurnPhase.PlayerTurn;
     return this.getState();
+  }
+
+  /** Get a random AI skill index (fallback when API unavailable) */
+  getRandomAiSkill(): number {
+    return Math.floor(Math.random() * this.state.opponent.skills.length);
   }
 
   /** Calculate damage with type effectiveness */
@@ -137,11 +146,6 @@ export class BattleManager {
   /** Get a snapshot of the current state */
   getState(): BattleState {
     return { ...this.state };
-  }
-
-  /** AI selects a random skill index */
-  private selectAiSkill(): number {
-    return Math.floor(Math.random() * this.state.opponent.skills.length);
   }
 
   private createEmptyState(): BattleState {

--- a/tests/BattleManager.test.ts
+++ b/tests/BattleManager.test.ts
@@ -132,50 +132,95 @@ describe("BattleManager", () => {
     });
   });
 
-  describe("executeTurn", () => {
-    it("should advance state through turn phases", () => {
+  describe("executePlayerAttack", () => {
+    it("should deal damage and move to AiThinking phase", () => {
       bm.initBattle(player, opponent);
-      const state = bm.executeTurn(0); // Fire Blast
-      // Fire vs Water opponent → 0.5x → 20 dmg
+      const state = bm.executePlayerAttack(0); // Fire Blast vs Water → 0.5x → 20
       assert.equal(state.opponent.hp, 80);
-      // AI should have attacked too (unless opponent died)
-      assert.ok(state.player.hp <= 100);
-      // Should be back to PLAYER_TURN or BATTLE_OVER
-      assert.ok(
-        state.phase === TurnPhase.PlayerTurn ||
-          state.phase === TurnPhase.BattleOver,
-      );
+      assert.equal(state.phase, TurnPhase.AiThinking);
     });
 
     it("should ignore invalid skill index", () => {
       bm.initBattle(player, opponent);
-      const state = bm.executeTurn(99);
+      const state = bm.executePlayerAttack(99);
       assert.equal(state.opponent.hp, 100);
       assert.equal(state.phase, TurnPhase.PlayerTurn);
     });
 
     it("should ignore negative skill index", () => {
       bm.initBattle(player, opponent);
-      const state = bm.executeTurn(-1);
+      const state = bm.executePlayerAttack(-1);
       assert.equal(state.opponent.hp, 100);
     });
 
-    it("should increment turn count", () => {
+    it("should not execute if not PLAYER_TURN phase", () => {
+      const lowHpOpponent = makeMech("Weak", MechType.Electric, 10);
+      bm.initBattle(player, lowHpOpponent);
+      bm.executePlayerAttack(0); // KO → BattleOver
+      const state = bm.executePlayerAttack(0); // Should be ignored
+      assert.equal(state.phase, TurnPhase.BattleOver);
+    });
+  });
+
+  describe("executeAiAttack", () => {
+    it("should deal damage and return to PlayerTurn", () => {
       bm.initBattle(player, opponent);
-      const state = bm.executeTurn(0);
+      bm.executePlayerAttack(0); // Move to AiThinking
+      // AI skill index 0 = Fire Blast (Fire, 40) vs Fire player → 1.0x → 40
+      const state = bm.executeAiAttack(0);
+      assert.equal(state.player.hp, 60);
+      assert.equal(state.phase, TurnPhase.PlayerTurn);
+      assert.equal(state.turnCount, 2);
+    });
+
+    it("should clamp out-of-range skill index", () => {
+      bm.initBattle(player, opponent);
+      bm.executePlayerAttack(0);
+      const state = bm.executeAiAttack(99); // Clamped to last skill
+      assert.ok(
+        state.phase === TurnPhase.PlayerTurn ||
+          state.phase === TurnPhase.BattleOver,
+      );
+    });
+
+    it("should ignore if not AiThinking phase", () => {
+      bm.initBattle(player, opponent);
+      const state = bm.executeAiAttack(0); // Phase is PlayerTurn, not AiThinking
+      assert.equal(state.phase, TurnPhase.PlayerTurn);
+      assert.equal(state.player.hp, 100);
+    });
+  });
+
+  describe("getRandomAiSkill", () => {
+    it("should return valid skill index", () => {
+      bm.initBattle(player, opponent);
+      for (let i = 0; i < 20; i++) {
+        const idx = bm.getRandomAiSkill();
+        assert.ok(idx >= 0 && idx < opponent.skills.length);
+      }
+    });
+  });
+
+  describe("full turn flow (player + AI)", () => {
+    it("should advance through full turn", () => {
+      bm.initBattle(player, opponent);
+      const afterPlayer = bm.executePlayerAttack(0);
+      assert.equal(afterPlayer.phase, TurnPhase.AiThinking);
+
+      const afterAi = bm.executeAiAttack(0);
+      assert.ok(
+        afterAi.phase === TurnPhase.PlayerTurn ||
+          afterAi.phase === TurnPhase.BattleOver,
+      );
+    });
+
+    it("should increment turn count after full turn", () => {
+      bm.initBattle(player, opponent);
+      bm.executePlayerAttack(0);
+      const state = bm.executeAiAttack(0);
       if (state.phase !== TurnPhase.BattleOver) {
         assert.equal(state.turnCount, 2);
       }
-    });
-
-    it("should not execute if not PLAYER_TURN phase", () => {
-      bm.initBattle(player, opponent);
-      // First execute a turn that ends the battle
-      const lowHpOpponent = makeMech("Weak", MechType.Electric, 10);
-      bm.initBattle(player, lowHpOpponent);
-      bm.executeTurn(0); // Should KO (Fire vs Electric = 1.5x * 40 = 60)
-      const state = bm.executeTurn(0); // Should be ignored
-      assert.equal(state.phase, TurnPhase.BattleOver);
     });
   });
 
@@ -233,23 +278,21 @@ describe("BattleManager", () => {
       const weakOpponent = makeMech("Weak", MechType.Electric, 1);
       bm.initBattle(player, weakOpponent);
       // Fire vs Electric = 1.5x * 40 = 60 → KO
-      const state = bm.executeTurn(0);
+      const state = bm.executePlayerAttack(0);
       assert.equal(state.phase, TurnPhase.BattleOver);
       assert.equal(state.winner, "player");
       assert.equal(state.opponent.hp, 0);
     });
 
     it("should end battle when player KO'd on AI turn", () => {
-      // Give player 1 HP, use defense skill (0 dmg) so opponent survives
       const weakPlayer = makeMech("Weak", MechType.Fire, 1);
       bm.initBattle(weakPlayer, opponent);
       // Use Iron Defense (index 3, 0 damage) so opponent survives
-      const state = bm.executeTurn(3);
-      // AI will attack, and any damage > 0 KOs player
-      if (state.phase === TurnPhase.BattleOver) {
-        assert.equal(state.winner, "opponent");
-      }
-      // If AI picked Iron Defense too, player survives - both outcomes valid
+      bm.executePlayerAttack(3);
+      // Water Cannon (index 0) vs Fire → 1.5x * 30 = 45 → KO
+      const state = bm.executeAiAttack(0);
+      assert.equal(state.phase, TurnPhase.BattleOver);
+      assert.equal(state.winner, "opponent");
     });
   });
 });

--- a/tests/battleClient.test.ts
+++ b/tests/battleClient.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it, mock } from "node:test";
+import { callBattleAPI } from "../src/api/battleClient";
+import type { BattleState } from "../src/types/game";
+import { MechType, TurnPhase } from "../src/types/game";
+
+function makeGameState(overrides?: Partial<BattleState>): BattleState {
+  return {
+    player: {
+      name: "PlayerMech",
+      type: MechType.Fire,
+      hp: 80,
+      maxHp: 100,
+      skills: [
+        { name: "Fire Blast", type: MechType.Fire, damage: 40 },
+        { name: "Water Cannon", type: MechType.Water, damage: 30 },
+        { name: "Thunder Shock", type: MechType.Electric, damage: 25 },
+        { name: "Iron Defense", type: "defense", damage: 0 },
+      ],
+    },
+    opponent: {
+      name: "EnemyMech",
+      type: MechType.Water,
+      hp: 60,
+      maxHp: 100,
+      skills: [
+        { name: "Water Cannon", type: MechType.Water, damage: 30 },
+        { name: "Fire Blast", type: MechType.Fire, damage: 40 },
+        { name: "Thunder Shock", type: MechType.Electric, damage: 25 },
+        { name: "Iron Defense", type: "defense", damage: 0 },
+      ],
+    },
+    phase: TurnPhase.AiThinking,
+    log: ["Battle Start!", "PlayerMech used Fire Blast!"],
+    turnCount: 1,
+    winner: null,
+    ...overrides,
+  };
+}
+
+describe("callBattleAPI", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    mock.restoreAll();
+  });
+
+  it("should return move on successful API response", async () => {
+    globalThis.fetch = mock.fn(async () =>
+      Response.json({ move: 2, reasoning: "strategic choice" }),
+    ) as typeof fetch;
+
+    const result = await callBattleAPI("be aggressive", makeGameState());
+    assert.deepEqual(result, { move: 2, reasoning: "strategic choice" });
+  });
+
+  it("should send correct request body", async () => {
+    const fetchMock = mock.fn(async () =>
+      Response.json({ move: 1 }),
+    ) as typeof fetch;
+    globalThis.fetch = fetchMock;
+
+    await callBattleAPI("test prompt", makeGameState());
+
+    assert.equal(fetchMock.mock.calls.length, 1);
+    const [url, options] = fetchMock.mock.calls[0].arguments;
+    assert.equal(url, "/api/battle");
+    assert.equal(options?.method, "POST");
+
+    const body = JSON.parse(options?.body as string);
+    assert.equal(body.mechPrompt, "test prompt");
+    assert.equal(body.gameState.playerHP, 80);
+    assert.equal(body.gameState.opponentHP, 60);
+    assert.equal(body.gameState.lastMove, "PlayerMech used Fire Blast!");
+  });
+
+  it("should return null after max retries on network error", async () => {
+    globalThis.fetch = mock.fn(async () => {
+      throw new TypeError("Failed to fetch");
+    }) as typeof fetch;
+
+    const result = await callBattleAPI("test", makeGameState());
+    assert.equal(result, null);
+
+    const calls = (globalThis.fetch as ReturnType<typeof mock.fn>).mock.calls;
+    assert.equal(calls.length, 2);
+  });
+
+  it("should return null after max retries on non-ok response", async () => {
+    globalThis.fetch = mock.fn(
+      async () => new Response("error", { status: 500 }),
+    ) as typeof fetch;
+
+    const result = await callBattleAPI("test", makeGameState());
+    assert.equal(result, null);
+  });
+
+  it("should retry on first failure then succeed", async () => {
+    let callCount = 0;
+    globalThis.fetch = mock.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        throw new TypeError("Failed to fetch");
+      }
+      return Response.json({ move: 3 });
+    }) as typeof fetch;
+
+    const result = await callBattleAPI("test", makeGameState());
+    assert.deepEqual(result, { move: 3 });
+    assert.equal(callCount, 2);
+  });
+
+  it("should return null for invalid move value", async () => {
+    globalThis.fetch = mock.fn(async () =>
+      Response.json({ move: 5 }),
+    ) as typeof fetch;
+
+    const result = await callBattleAPI("test", makeGameState());
+    assert.equal(result, null);
+  });
+
+  it("should extract last move from log", async () => {
+    const fetchMock = mock.fn(async () =>
+      Response.json({ move: 0 }),
+    ) as typeof fetch;
+    globalThis.fetch = fetchMock;
+
+    const state = makeGameState({
+      log: [
+        "Battle Start!",
+        "PlayerMech used Fire Blast!",
+        "It's not very effective...",
+        "EnemyMech used Water Cannon!",
+      ],
+    });
+
+    await callBattleAPI("test", state);
+
+    const body = JSON.parse(
+      fetchMock.mock.calls[0].arguments[1]?.body as string,
+    );
+    assert.equal(body.gameState.lastMove, "EnemyMech used Water Cannon!");
+  });
+});


### PR DESCRIPTION
## Summary
Replace Bot random moves with LLM-powered AI decisions via Claude Haiku.

## Changes
- **src/api/battleClient.ts** (new)
  - `callBattleAPI(prompt, gameState)` function
  - Retry logic (max 2 retries)
  - Network error handling
- **src/utils/BattleManager.ts**
  - Split `executeTurn()` into `executePlayerAttack()` + `executeAiAttack()`
  - `getRandomAiSkill()` for fallback
- **src/scenes/BattleScene.ts**
  - Prompt input UI (textarea + Save button)
  - 500 character limit
  - localStorage persistence (`mechArena_battlePrompt`)
  - Loading state during API call
- **tests/battleClient.test.ts** (new) - 7 tests
- **tests/BattleManager.test.ts** - updated for new API

## Test Results
✅ 48 tests passed

## Acceptance Criteria
- [x] AI moves determined by LLM
- [x] Player can input/edit prompt
- [x] Prompt persists across sessions
- [x] API errors handled gracefully
- [x] Loading state visible during API call
- [x] Fallback to random on failure

Closes #7