### PR TITLE
fix: Actually load SVG sprites using base64 data URI

### DIFF
--- a/src/utils/MechGraphics.ts
+++ b/src/utils/MechGraphics.ts
@@ -6,15 +6,28 @@
 import type Phaser from "phaser";
 import { MechType } from "../types/game";
 
-import electricMechSvg from "../assets/mechs/electric-mech.svg?url";
-// SVG asset imports (resolved by Vite as URLs via ?url suffix)
-import fireMechSvg from "../assets/mechs/fire-mech.svg?url";
-import waterMechSvg from "../assets/mechs/water-mech.svg?url";
+// SVG imports as raw strings for base64 data URI conversion (most reliable for Phaser)
+import electricMechSvgRaw from "../assets/mechs/electric-mech.svg?raw";
+import fireMechSvgRaw from "../assets/mechs/fire-mech.svg?raw";
+import waterMechSvgRaw from "../assets/mechs/water-mech.svg?raw";
 
-const SVG_TEXTURE_KEYS: Record<string, { key: string; url: string }> = {
-  [MechType.Fire]: { key: "mech-fire", url: fireMechSvg },
-  [MechType.Water]: { key: "mech-water", url: waterMechSvg },
-  [MechType.Electric]: { key: "mech-electric", url: electricMechSvg },
+/** Convert SVG string to base64 data URI */
+function svgToDataUri(svgString: string): string {
+  // Encode as base64 for reliable cross-browser support
+  const base64 = btoa(unescape(encodeURIComponent(svgString)));
+  return `data:image/svg+xml;base64,${base64}`;
+}
+
+const SVG_TEXTURE_KEYS: Record<string, { key: string; dataUri: string }> = {
+  [MechType.Fire]: { key: "mech-fire", dataUri: svgToDataUri(fireMechSvgRaw) },
+  [MechType.Water]: {
+    key: "mech-water",
+    dataUri: svgToDataUri(waterMechSvgRaw),
+  },
+  [MechType.Electric]: {
+    key: "mech-electric",
+    dataUri: svgToDataUri(electricMechSvgRaw),
+  },
 };
 
 const MECH_COLORS: Record<
@@ -664,14 +677,13 @@ export interface MechSprite {
  */
 export function preloadMechSVGs(scene: Phaser.Scene): void {
   for (const [type, entry] of Object.entries(SVG_TEXTURE_KEYS)) {
-    console.log(
-      `[MechGraphics] Loading SVG: ${entry.key} from ${entry.url.substring(0, 60)}...`,
-    );
+    console.log(`[MechGraphics] Loading SVG: ${entry.key} (base64 data URI)`);
     if (scene.textures.exists(entry.key)) continue;
 
     try {
-      // Phaser's SVG loader works with both regular URLs and data URIs
-      scene.load.svg(entry.key, entry.url, { width: 128, height: 128 });
+      // Use base64 data URI - most reliable method for Phaser SVG loading
+      scene.load.svg(entry.key, entry.dataUri, { width: 128, height: 128 });
+      console.log(`[MechGraphics] Queued SVG load: ${entry.key}`);
     } catch (err) {
       console.warn(
         `[MechGraphics] Failed to queue SVG load for ${type}, will use programmatic fallback:`,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,12 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/client" />
 
+// SVG raw string imports
+declare module "*.svg?raw" {
+  const content: string;
+  export default content;
+}
+
 declare module "virtual:pwa-register" {
   interface RegisterSWOptions {
     immediate?: boolean;


### PR DESCRIPTION
## Problem
Previous fix (PR #25) only made fallback more graceful, but SVG sprites still failed to load in production. Users see programmatic circles/triangles instead of professional SVG mechs.

## Root Cause
Phaser's `scene.load.svg()` with URL paths doesn't work reliably in production builds.

## Solution
Use **base64 data URI** - the most reliable method per FR #26:
- Import SVG as raw strings via `?raw` suffix
- Convert to base64 data URI at build time
- Pass data URI to Phaser's SVG loader

## Changes
- **src/utils/MechGraphics.ts**
  - Changed from `?url` to `?raw` imports
  - Added `svgToDataUri()` helper function
  - SVG content now embedded in JS bundle as base64
- **src/vite-env.d.ts**
  - Added type declaration for `*.svg?raw` imports

## Why This Works
- No external file requests needed
- No CORS issues
- No path resolution problems
- SVG data is bundled directly into JS
- Phaser receives valid base64 data URI

## Test Results
✅ 71 tests passed
✅ Build successful (SVG embedded in bundle)

Closes #27