### PR TITLE
feat: add attack projectile and hit reaction animations

### DIFF
--- a/src/scenes/BattleScene.ts
+++ b/src/scenes/BattleScene.ts
@@ -13,6 +13,8 @@ import {
   type PortraitState,
   createMechSprite,
   getPortraitState,
+  playAttackAnimation,
+  playHitReaction,
   playMechAttack,
   playMechDamageFlash,
   preloadMechSVGs,
@@ -926,6 +928,7 @@ export class BattleScene extends Phaser.Scene {
     const prevLogLen = state.log.length;
 
     // --- Phase 1: Player attack ---
+    const playerSkill = state.player.skills[index];
     const afterPlayer = this.battleManager.executePlayerAttack(index);
     const playerLogs = afterPlayer.log.slice(prevLogLen);
 
@@ -934,10 +937,22 @@ export class BattleScene extends Phaser.Scene {
       this.addLogMessage(msg);
     }
 
-    await this.playAttackAnimation(true);
-
-    if (afterPlayer.opponent.hp < prevOpponentHp) {
-      await this.playDamageFlash(true);
+    const playerDidDamage = afterPlayer.opponent.hp < prevOpponentHp;
+    if (playerDidDamage && playerSkill.type !== "defense") {
+      // Enhanced animation: projectile + hit reaction
+      await playAttackAnimation(
+        this,
+        this.playerMechSprite,
+        this.opponentMechSprite,
+        playerSkill.type,
+      );
+      await playHitReaction(this, this.opponentMechSprite, playerSkill.type);
+    } else {
+      // Fallback: simple lunge + optional flash
+      await this.playAttackAnimation(true);
+      if (playerDidDamage) {
+        await this.playDamageFlash(true);
+      }
     }
 
     await this.animateHP(
@@ -977,15 +992,35 @@ export class BattleScene extends Phaser.Scene {
     const afterAi = this.battleManager.executeAiAttack(aiSkillIndex);
     const aiLogs = afterAi.log.slice(aiLogLen);
 
+    const aiSkill =
+      afterAi.opponent.skills[
+        Math.max(
+          0,
+          Math.min(aiSkillIndex, afterAi.opponent.skills.length - 1),
+        )
+      ];
+
     this.setTurnIndicator(TurnPhase.AiTurn);
     for (const msg of aiLogs) {
       this.addLogMessage(msg);
     }
 
-    await this.playAttackAnimation(false);
-
-    if (afterAi.player.hp < prevPlayerHp) {
-      await this.playDamageFlash(false);
+    const aiDidDamage = afterAi.player.hp < prevPlayerHp;
+    if (aiDidDamage && aiSkill.type !== "defense") {
+      // Enhanced animation: projectile + hit reaction
+      await playAttackAnimation(
+        this,
+        this.opponentMechSprite,
+        this.playerMechSprite,
+        aiSkill.type,
+      );
+      await playHitReaction(this, this.playerMechSprite, aiSkill.type);
+    } else {
+      // Fallback: simple lunge + optional flash
+      await this.playAttackAnimation(false);
+      if (aiDidDamage) {
+        await this.playDamageFlash(false);
+      }
     }
 
     await this.animateHP(

--- a/src/utils/MechGraphics.ts
+++ b/src/utils/MechGraphics.ts
@@ -678,6 +678,10 @@ const EFFECT_FN: Record<
   [MechType.Electric]: createElectricEffects,
 };
 
+// Re-export projectile color utilities (pure module)
+export { PROJECTILE_COLORS, getProjectileColors } from "./projectileColors";
+import { getProjectileColors } from "./projectileColors";
+
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 export interface MechSprite {
@@ -901,6 +905,202 @@ export function playMechDamageFlash(
       repeat: 2,
       onComplete: () => {
         sprite.container.setAlpha(1);
+      },
+    });
+  });
+}
+
+/**
+ * Play ranged attack animation: muzzle flash at attacker + projectile flying to target.
+ * Returns a Promise that resolves when the projectile reaches the target.
+ */
+export function playAttackAnimation(
+  scene: Phaser.Scene,
+  attacker: MechSprite,
+  target: MechSprite,
+  skillType: MechType,
+): Promise<void> {
+  return new Promise((resolve) => {
+    const colors = getProjectileColors(skillType);
+
+    const ax = attacker.container.x;
+    const ay = attacker.container.y;
+    const tx = target.container.x;
+    const ty = target.container.y;
+
+    const dx = tx - ax;
+    const dy = ty - ay;
+    const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+    const normX = dx / dist;
+    const normY = dy / dist;
+
+    // Muzzle flash at attacker front
+    const flashX = ax + normX * 30;
+    const flashY = ay + normY * 30;
+    const flash = scene.add.graphics();
+    flash.fillStyle(colors.core, 0.9);
+    flash.fillCircle(0, 0, 12);
+    flash.fillStyle(0xffffff, 0.7);
+    flash.fillCircle(0, 0, 6);
+    flash.setPosition(flashX, flashY);
+
+    scene.tweens.add({
+      targets: flash,
+      alpha: 0,
+      scaleX: 2,
+      scaleY: 2,
+      duration: 150,
+      onComplete: () => flash.destroy(),
+    });
+
+    // Attacker recoil
+    attacker.idleTween.pause();
+    scene.tweens.add({
+      targets: attacker.container,
+      x: ax - normX * 15,
+      y: ay - normY * 10,
+      duration: 80,
+      yoyo: true,
+      ease: "Power2",
+      onComplete: () => attacker.idleTween.resume(),
+    });
+
+    // Projectile
+    const projectile = scene.add.graphics();
+    projectile.fillStyle(colors.glow, 1);
+    projectile.fillCircle(0, 0, 8);
+    projectile.fillStyle(colors.core, 1);
+    projectile.fillCircle(0, 0, 4);
+    projectile.setPosition(flashX, flashY);
+
+    // Trail particles during flight
+    const trailTimer = scene.time.addEvent({
+      delay: 35,
+      loop: true,
+      callback: () => {
+        const trail = scene.add.graphics();
+        trail.fillStyle(colors.trail, 0.6);
+        trail.fillCircle(0, 0, 2 + Math.random() * 2);
+        trail.setPosition(projectile.x, projectile.y);
+        scene.tweens.add({
+          targets: trail,
+          alpha: 0,
+          scaleX: 0.3,
+          scaleY: 0.3,
+          duration: 200,
+          onComplete: () => trail.destroy(),
+        });
+      },
+    });
+
+    // Projectile flight to target
+    scene.tweens.add({
+      targets: projectile,
+      x: tx,
+      y: ty,
+      duration: 300,
+      ease: "Power1",
+      onComplete: () => {
+        trailTimer.destroy();
+        projectile.destroy();
+        resolve();
+      },
+    });
+  });
+}
+
+/**
+ * Play hit reaction: explosion burst + target shake + damage flash.
+ * Returns a Promise that resolves when the reaction animation completes.
+ */
+export function playHitReaction(
+  scene: Phaser.Scene,
+  target: MechSprite,
+  damageType: MechType,
+): Promise<void> {
+  return new Promise((resolve) => {
+    const colors = getProjectileColors(damageType);
+    const tx = target.container.x;
+    const ty = target.container.y;
+
+    // Explosion sparks
+    const sparkCount = 6;
+    for (let i = 0; i < sparkCount; i++) {
+      const spark = scene.add.graphics();
+      const offX = (Math.random() - 0.5) * 50;
+      const offY = (Math.random() - 0.5) * 50;
+      spark.fillStyle(i < 2 ? 0xffffff : colors.core, 0.9);
+      spark.fillCircle(0, 0, 3 + Math.random() * 4);
+      spark.setPosition(tx + offX, ty + offY);
+
+      scene.tweens.add({
+        targets: spark,
+        alpha: 0,
+        scaleX: 2 + Math.random(),
+        scaleY: 2 + Math.random(),
+        x: tx + offX * 2.5,
+        y: ty + offY * 2.5 - 15,
+        duration: 300 + Math.random() * 200,
+        delay: i * 25,
+        onComplete: () => spark.destroy(),
+      });
+    }
+
+    // Central explosion flash
+    const blast = scene.add.graphics();
+    blast.fillStyle(colors.glow, 0.8);
+    blast.fillCircle(0, 0, 22);
+    blast.fillStyle(0xffffff, 0.6);
+    blast.fillCircle(0, 0, 10);
+    blast.setPosition(tx, ty);
+
+    scene.tweens.add({
+      targets: blast,
+      alpha: 0,
+      scaleX: 3,
+      scaleY: 3,
+      duration: 350,
+      onComplete: () => blast.destroy(),
+    });
+
+    // Target shake
+    const origX = target.container.x;
+    target.idleTween.pause();
+
+    scene.tweens.add({
+      targets: target.container,
+      x: origX + 8,
+      duration: 40,
+      yoyo: true,
+      repeat: 3,
+      onComplete: () => {
+        target.container.x = origX;
+        target.idleTween.resume();
+      },
+    });
+
+    // Damage overlay flash
+    scene.tweens.add({
+      targets: target.damageOverlay,
+      alpha: 0.6,
+      duration: 80,
+      yoyo: true,
+      repeat: 2,
+      onComplete: () => {
+        target.damageOverlay.setAlpha(0);
+      },
+    });
+
+    // Container alpha flash — resolve when this completes
+    scene.tweens.add({
+      targets: target.container,
+      alpha: 0.3,
+      duration: 80,
+      yoyo: true,
+      repeat: 2,
+      onComplete: () => {
+        target.container.setAlpha(1);
+        resolve();
       },
     });
   });

--- a/src/utils/projectileColors.ts
+++ b/src/utils/projectileColors.ts
@@ -1,0 +1,24 @@
+/**
+ * Projectile / explosion color definitions — pure module, no asset imports.
+ */
+
+import { MechType } from "../types/game";
+
+export const PROJECTILE_COLORS: Record<
+  string,
+  { core: number; glow: number; trail: number }
+> = {
+  [MechType.Fire]: { core: 0xffaa00, glow: 0xff4500, trail: 0xff6600 },
+  [MechType.Water]: { core: 0x00ddff, glow: 0x1e90ff, trail: 0x4db8ff },
+  [MechType.Electric]: { core: 0xffff00, glow: 0xffd700, trail: 0xffed4a },
+};
+
+/**
+ * Get projectile/explosion colors for a skill type.
+ * Falls back to fire colors for unknown types.
+ */
+export function getProjectileColors(
+  skillType: string,
+): { core: number; glow: number; trail: number } {
+  return PROJECTILE_COLORS[skillType] ?? PROJECTILE_COLORS[MechType.Fire];
+}

--- a/tests/attackAnimation.test.ts
+++ b/tests/attackAnimation.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { MechType } from "../src/types/game";
+import {
+  PROJECTILE_COLORS,
+  getProjectileColors,
+} from "../src/utils/projectileColors";
+
+describe("getProjectileColors", () => {
+  it("should return fire colors for fire type", () => {
+    const colors = getProjectileColors(MechType.Fire);
+    assert.deepEqual(colors, PROJECTILE_COLORS[MechType.Fire]);
+    assert.equal(colors.core, 0xffaa00);
+    assert.equal(colors.glow, 0xff4500);
+    assert.equal(colors.trail, 0xff6600);
+  });
+
+  it("should return water colors for water type", () => {
+    const colors = getProjectileColors(MechType.Water);
+    assert.deepEqual(colors, PROJECTILE_COLORS[MechType.Water]);
+    assert.equal(colors.core, 0x00ddff);
+    assert.equal(colors.glow, 0x1e90ff);
+    assert.equal(colors.trail, 0x4db8ff);
+  });
+
+  it("should return electric colors for electric type", () => {
+    const colors = getProjectileColors(MechType.Electric);
+    assert.deepEqual(colors, PROJECTILE_COLORS[MechType.Electric]);
+    assert.equal(colors.core, 0xffff00);
+    assert.equal(colors.glow, 0xffd700);
+    assert.equal(colors.trail, 0xffed4a);
+  });
+
+  it("should fall back to fire colors for unknown type", () => {
+    const colors = getProjectileColors("unknown");
+    assert.deepEqual(colors, PROJECTILE_COLORS[MechType.Fire]);
+  });
+
+  it("should fall back to fire colors for empty string", () => {
+    const colors = getProjectileColors("");
+    assert.deepEqual(colors, PROJECTILE_COLORS[MechType.Fire]);
+  });
+
+  it("should return an object with core, glow, and trail keys", () => {
+    for (const type of [MechType.Fire, MechType.Water, MechType.Electric]) {
+      const colors = getProjectileColors(type);
+      assert.ok("core" in colors, `${type} missing core`);
+      assert.ok("glow" in colors, `${type} missing glow`);
+      assert.ok("trail" in colors, `${type} missing trail`);
+      assert.equal(typeof colors.core, "number");
+      assert.equal(typeof colors.glow, "number");
+      assert.equal(typeof colors.trail, "number");
+    }
+  });
+
+  it("should cover all MechType values in PROJECTILE_COLORS", () => {
+    for (const type of Object.values(MechType)) {
+      assert.ok(
+        PROJECTILE_COLORS[type] !== undefined,
+        `Missing color entry for ${type}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add `playAttackAnimation()` — muzzle flash + projectile with trail particles flying from attacker to target
- Add `playHitReaction()` — explosion burst sparks + central flash + target shake + damage overlay flash
- Extract `projectileColors.ts` as pure module for per-element-type color configs (fire/water/electric)
- Update `BattleScene.onSkillSelected()` to use enhanced animation chain for damage-dealing skills, fallback to simple lunge for defense
- Add 7 unit tests for `getProjectileColors` covering all types + fallback behavior

Closes #39

## Test plan
- [x] All 86 unit tests pass (`npm test`)
- [x] Vite production build succeeds (`npx vite build`)
- [ ] Manual: fire skill shows orange projectile + explosion on target
- [ ] Manual: water skill shows blue projectile + explosion on target
- [ ] Manual: electric skill shows yellow projectile + explosion on target
- [ ] Manual: defense skill still shows simple lunge (no projectile)
- [ ] Manual: AI attacks trigger same animation chain on player mech
- [ ] Manual: battle flow and turn order unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)