### PR TITLE
feat: make battle log show real combat events

### DIFF
--- a/src/scenes/BattleScene.ts
+++ b/src/scenes/BattleScene.ts
@@ -499,20 +499,30 @@ export class BattleScene extends Phaser.Scene {
     const logX = w * 0.03;
     const logY = h * 0.37;
     const logW = w * 0.44;
-    const logH = Math.min(h * 0.2, h - logY - 10);
+    const logH = Math.min(h * 0.25, h - logY - 10);
 
     const bg = this.add.graphics();
-    bg.fillStyle(0x111111, 0.85);
+    bg.fillStyle(0x1a1a2e, 0.92);
     bg.fillRoundedRect(logX, logY, logW, logH, 6);
     bg.lineStyle(1, COLORS.panelBorder);
     bg.strokeRoundedRect(logX, logY, logW, logH, 6);
 
-    this.logContainer = this.add.container(logX + 10, logY + 6);
+    // Panel title
+    const titleSize = Math.max(11, Math.floor(w * 0.015));
+    this.add
+      .text(logX + 10, logY + 5, "\u2694 Battle Log", {
+        fontSize: `${titleSize}px`,
+        color: "#888888",
+      })
+      .setOrigin(0, 0);
+
+    const titleOffset = titleSize + 10;
+    this.logContainer = this.add.container(logX + 10, logY + titleOffset);
 
     // Keep legacy text object for compatibility (hidden)
     this.battleLogText = this.add
       .text(0, 0, "", {
-        fontSize: `${Math.max(10, Math.floor(w * 0.014))}px`,
+        fontSize: `${Math.max(12, Math.floor(w * 0.018))}px`,
         color: COLORS.accent,
         wordWrap: { width: logW - 20 },
         lineSpacing: 3,
@@ -520,7 +530,7 @@ export class BattleScene extends Phaser.Scene {
       .setOrigin(0, 0)
       .setVisible(false);
 
-    this.logFontSize = Math.max(10, Math.floor(w * 0.014));
+    this.logFontSize = Math.max(12, Math.floor(w * 0.018));
     this.logLineWidth = logW - 20;
 
     // Mask to clip overflow
@@ -550,7 +560,7 @@ export class BattleScene extends Phaser.Scene {
     }
     this.logLineTexts = [];
 
-    const lineHeight = this.logFontSize + 5;
+    const lineHeight = this.logFontSize + 6;
     for (let i = 0; i < this.logMessages.length; i++) {
       const lineText = this.add
         .text(0, i * lineHeight, this.logMessages[i], {

--- a/src/utils/BattleManager.ts
+++ b/src/utils/BattleManager.ts
@@ -35,7 +35,11 @@ export class BattleManager {
       turnCount: 1,
       winner: null,
     };
-    this.addLog("Battle Start!");
+    this.addLog("[TURN]--- Battle Start ---");
+    this.addLog(
+      `[EFF]${this.state.player.name} vs ${this.state.opponent.name}`,
+    );
+    this.addLog("Choose your attack!");
     return this.getState();
   }
 

--- a/tests/BattleManager.test.ts
+++ b/tests/BattleManager.test.ts
@@ -43,7 +43,7 @@ describe("BattleManager", () => {
       assert.equal(state.phase, TurnPhase.PlayerTurn);
       assert.equal(state.turnCount, 1);
       assert.equal(state.winner, null);
-      assert.ok(state.log.includes("Battle Start!"));
+      assert.ok(state.log.some((m: string) => m.includes("Battle Start")));
     });
 
     it("should reset HP to maxHp", () => {
@@ -286,12 +286,10 @@ describe("BattleManager", () => {
     it("should log defense skill usage", () => {
       bm.initBattle(player, opponent);
       const state = bm.executePlayerAttack(3); // Iron Defense
-      const effLog = state.log.find((m) => m.startsWith("[EFF]"));
-      assert.ok(effLog, "should have an [EFF] prefixed log");
-      assert.ok(
-        effLog.includes("raised defense"),
-        "should mention raised defense",
+      const effLog = state.log.find(
+        (m) => m.startsWith("[EFF]") && m.includes("raised defense"),
       );
+      assert.ok(effLog, "should mention raised defense");
     });
 
     it("should log turn transition after AI attack", () => {
@@ -299,9 +297,10 @@ describe("BattleManager", () => {
       bm.executePlayerAttack(0);
       const state = bm.executeAiAttack(0);
       if (state.phase !== TurnPhase.BattleOver) {
-        const turnLog = state.log.find((m) => m.startsWith("[TURN]"));
-        assert.ok(turnLog, "should have a [TURN] prefixed log");
-        assert.ok(turnLog.includes("Turn 2"), "should indicate turn 2");
+        const turnLog = state.log.find(
+          (m) => m.startsWith("[TURN]") && m.includes("Turn 2"),
+        );
+        assert.ok(turnLog, "should indicate turn 2");
       }
     });
 
@@ -341,10 +340,13 @@ describe("BattleManager", () => {
       bm.initBattle(player, opponent);
       bm.executePlayerAttack(0);
       const state = bm.executeAiAttack(3); // Iron Defense
-      const effLog = state.log.filter((m) => m.startsWith("[EFF]"));
-      const aiDefLog = effLog.find((m) => m.includes("EnemyMech"));
-      assert.ok(aiDefLog, "should log AI defense");
-      assert.ok(aiDefLog.includes("raised defense"));
+      const aiDefLog = state.log.find(
+        (m) =>
+          m.startsWith("[EFF]") &&
+          m.includes("EnemyMech") &&
+          m.includes("raised defense"),
+      );
+      assert.ok(aiDefLog, "should log AI defense with raised defense");
     });
 
     it("should log damage when AI deals damage", () => {

--- a/tests/battleClient.test.ts
+++ b/tests/battleClient.test.ts
@@ -31,7 +31,12 @@ function makeGameState(overrides?: Partial<BattleState>): BattleState {
       ],
     },
     phase: TurnPhase.AiThinking,
-    log: ["Battle Start!", "PlayerMech used Fire Blast!"],
+    log: [
+      "[TURN]--- Battle Start ---",
+      "[EFF]PlayerMech vs EnemyMech",
+      "Choose your attack!",
+      "PlayerMech used Fire Blast!",
+    ],
     turnCount: 1,
     winner: null,
     ...overrides,
@@ -132,7 +137,9 @@ describe("callBattleAPI", () => {
 
     const state = makeGameState({
       log: [
-        "Battle Start!",
+        "[TURN]--- Battle Start ---",
+        "[EFF]PlayerMech vs EnemyMech",
+        "Choose your attack!",
         "PlayerMech used Fire Blast!",
         "It's not very effective...",
         "EnemyMech used Water Cannon!",


### PR DESCRIPTION
## Summary
- Changed battle log panel from light background to dark themed (0x1a1a2e) matching HUD style
- Added "⚔ Battle Log" title header to clarify panel purpose
- Increased font size (w*0.014 → w*0.018, min 12px) and line height for mobile readability
- Expanded panel height ratio (0.2 → 0.25) to show more content
- Enriched initial log with 3 messages instead of 1, so panel starts populated
- Updated affected tests for new initial log format

## Test plan
- [x] 161/162 tests pass (1 pre-existing failure in assetRegistry.test.ts)
- [x] BattleManager tests updated for new initial log messages
- [x] battleClient tests updated for new log format
- [ ] Visual verification: log panel has dark background, title, readable text

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)