### PR TITLE
feat: add stronger attack and hit feedback during battle

### DIFF
--- a/src/scenes/BattleScene.ts
+++ b/src/scenes/BattleScene.ts
@@ -19,6 +19,8 @@ import {
   playMechAttack,
   playMechDamageFlash,
   preloadMechAssets,
+  showDamageNumber,
+  showSkillName,
 } from "../utils/MechGraphics";
 import {
   BATTLE_BG_TINT,
@@ -1064,6 +1066,11 @@ export class BattleScene extends Phaser.Scene {
       this.addLogMessage(msg);
     }
 
+    await showSkillName(
+      this,
+      playerSkill.name,
+      SKILL_COLORS[playerSkill.type] ?? COLORS.accent,
+    );
     await this.playAttackAnimation(true);
     await playAttackProjectile(
       this,
@@ -1072,19 +1079,32 @@ export class BattleScene extends Phaser.Scene {
       playerSkill.type,
     );
 
-    if (afterPlayer.opponent.hp < prevOpponentHp) {
+    const playerDmg = prevOpponentHp - afterPlayer.opponent.hp;
+    if (playerDmg > 0) {
+      const eff = playerLogs.some((m: string) => m.startsWith("[SUP]"))
+        ? "super"
+        : playerLogs.some((m: string) => m.startsWith("[RES]"))
+          ? "resist"
+          : "normal";
+      showDamageNumber(this, this.opponentMechSprite, playerDmg, eff);
       await Promise.all([
         playHitReaction(this, this.opponentMechSprite, playerSkill.type),
         this.playDamageFlash(true),
+        this.animateHP(
+          true,
+          afterPlayer.opponent.hp / afterPlayer.opponent.maxHp,
+          afterPlayer.opponent.hp,
+          afterPlayer.opponent.maxHp,
+        ),
       ]);
+    } else {
+      await this.animateHP(
+        true,
+        afterPlayer.opponent.hp / afterPlayer.opponent.maxHp,
+        afterPlayer.opponent.hp,
+        afterPlayer.opponent.maxHp,
+      );
     }
-
-    await this.animateHP(
-      true,
-      afterPlayer.opponent.hp / afterPlayer.opponent.maxHp,
-      afterPlayer.opponent.hp,
-      afterPlayer.opponent.maxHp,
-    );
 
     // Check if opponent defeated
     if (afterPlayer.winner === "player") {
@@ -1123,6 +1143,11 @@ export class BattleScene extends Phaser.Scene {
       this.addLogMessage(msg);
     }
 
+    await showSkillName(
+      this,
+      aiSkill.name,
+      SKILL_COLORS[aiSkill.type] ?? COLORS.accent,
+    );
     await this.playAttackAnimation(false);
     await playAttackProjectile(
       this,
@@ -1131,19 +1156,32 @@ export class BattleScene extends Phaser.Scene {
       aiSkill.type,
     );
 
-    if (afterAi.player.hp < prevPlayerHp) {
+    const aiDmg = prevPlayerHp - afterAi.player.hp;
+    if (aiDmg > 0) {
+      const eff = aiLogs.some((m: string) => m.startsWith("[SUP]"))
+        ? "super"
+        : aiLogs.some((m: string) => m.startsWith("[RES]"))
+          ? "resist"
+          : "normal";
+      showDamageNumber(this, this.playerMechSprite, aiDmg, eff);
       await Promise.all([
         playHitReaction(this, this.playerMechSprite, aiSkill.type),
         this.playDamageFlash(false),
+        this.animateHP(
+          false,
+          afterAi.player.hp / afterAi.player.maxHp,
+          afterAi.player.hp,
+          afterAi.player.maxHp,
+        ),
       ]);
+    } else {
+      await this.animateHP(
+        false,
+        afterAi.player.hp / afterAi.player.maxHp,
+        afterAi.player.hp,
+        afterAi.player.maxHp,
+      );
     }
-
-    await this.animateHP(
-      false,
-      afterAi.player.hp / afterAi.player.maxHp,
-      afterAi.player.hp,
-      afterAi.player.maxHp,
-    );
 
     // Check if player defeated
     if (afterAi.winner === "opponent") {

--- a/src/utils/MechGraphics.ts
+++ b/src/utils/MechGraphics.ts
@@ -524,4 +524,9 @@ export function playMechDamageFlash(
 }
 
 // Re-export attack effect functions from dedicated module
-export { playAttackProjectile, playHitReaction } from "./attackEffects";
+export {
+  playAttackProjectile,
+  playHitReaction,
+  showDamageNumber,
+  showSkillName,
+} from "./attackEffects";

--- a/src/utils/attackEffects.ts
+++ b/src/utils/attackEffects.ts
@@ -125,6 +125,9 @@ export function playHitReaction(
       onComplete: () => explosion.destroy(),
     });
 
+    // Camera shake for impact (guard for test environments without cameras)
+    scene.cameras?.main?.shake(150, 0.005);
+
     // Container shake (rapid X oscillation)
     const origX = target.container.x;
     scene.tweens.add({
@@ -137,6 +140,82 @@ export function playHitReaction(
       onComplete: () => {
         target.container.x = origX;
         resolve();
+      },
+    });
+  });
+}
+
+/**
+ * Show a floating damage number above a mech that drifts up and fades out.
+ */
+export function showDamageNumber(
+  scene: Phaser.Scene,
+  target: MechSprite,
+  damage: number,
+  effectiveness: "super" | "resist" | "normal",
+): void {
+  const colorMap = { super: "#ff6666", resist: "#66ccff", normal: "#ffd700" };
+  const color = colorMap[effectiveness];
+  const prefix = damage > 0 ? "-" : "";
+
+  const text = scene.add
+    .text(target.container.x, target.container.y - 30, `${prefix}${damage}`, {
+      fontSize: "22px",
+      color,
+      fontStyle: "bold",
+      stroke: "#000000",
+      strokeThickness: 3,
+    })
+    .setOrigin(0.5);
+
+  scene.tweens.add({
+    targets: text,
+    y: text.y - 40,
+    alpha: 0,
+    duration: 800,
+    ease: "Quad.easeOut",
+    onComplete: () => text.destroy(),
+  });
+}
+
+/**
+ * Flash a skill name at the center of the screen, then fade out.
+ */
+export function showSkillName(
+  scene: Phaser.Scene,
+  skillName: string,
+  color: string,
+): Promise<void> {
+  return new Promise((resolve) => {
+    const { width, height } = scene.scale;
+    const text = scene.add
+      .text(width / 2, height * 0.3, skillName, {
+        fontSize: "24px",
+        color,
+        fontStyle: "bold",
+        stroke: "#000000",
+        strokeThickness: 4,
+      })
+      .setOrigin(0.5)
+      .setAlpha(0);
+
+    scene.tweens.add({
+      targets: text,
+      alpha: 1,
+      duration: 150,
+      ease: "Linear",
+      onComplete: () => {
+        scene.tweens.add({
+          targets: text,
+          alpha: 0,
+          duration: 450,
+          delay: 200,
+          ease: "Quad.easeIn",
+          onComplete: () => {
+            text.destroy();
+            resolve();
+          },
+        });
       },
     });
   });


### PR DESCRIPTION
## Summary
- Added camera shake on hit impact (150ms, low intensity for mobile safety)
- Added floating damage numbers above target mech (colored by effectiveness: gold=normal, red=super, blue=resist)
- Added skill name flash at screen center before each attack animation
- Synced HP bar animation with hit reaction (parallel instead of sequential)
- All effects use lightweight Phaser tweens, safe for mobile

## Test plan
- [x] 161/162 tests pass (1 pre-existing failure in assetRegistry.test.ts)
- [x] Attack animation tests (8/8) pass with camera shake guard
- [ ] Visual verification: skill name flash, damage numbers, camera shake, synced HP

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)