### PR TITLE
feat: make prompt strategy visibly affect battle behavior

### DIFF
--- a/src/scenes/BattleScene.ts
+++ b/src/scenes/BattleScene.ts
@@ -599,13 +599,16 @@ export class BattleScene extends Phaser.Scene {
 
   private showSpinner(): void {
     let i = 0;
+    const label = this.mechPrompt.trim()
+      ? "Analyzing strategy..."
+      : "AI Thinking...";
     this.spinnerText.setVisible(true);
     this.spinnerTimer = this.time.addEvent({
       delay: 80,
       loop: true,
       callback: () => {
         this.spinnerText.setText(
-          `${SPINNER_FRAMES[i]} AI Thinking... ${SPINNER_FRAMES[i]}`,
+          `${SPINNER_FRAMES[i]} ${label} ${SPINNER_FRAMES[i]}`,
         );
         i = (i + 1) % SPINNER_FRAMES.length;
       },
@@ -664,7 +667,20 @@ export class BattleScene extends Phaser.Scene {
       }, 1000);
     });
 
+    const indicator = document.createElement("span");
+    indicator.style.cssText =
+      "color:#0f8;font-size:11px;font-family:monospace;display:none;";
+    indicator.textContent = "\u26A1 Strategy Active";
+    if (this.mechPrompt.trim()) {
+      indicator.style.display = "inline";
+    }
+
+    saveBtn.addEventListener("click", () => {
+      indicator.style.display = this.mechPrompt.trim() ? "inline" : "none";
+    });
+
     row.appendChild(counter);
+    row.appendChild(indicator);
     row.appendChild(saveBtn);
     container.appendChild(textarea);
     container.appendChild(row);
@@ -1118,12 +1134,14 @@ export class BattleScene extends Phaser.Scene {
     this.showSpinner();
 
     let aiSkillIndex: number;
+    let aiReasoning: string | undefined;
     if (this.mechPrompt.trim() && isOnline()) {
       const apiResult = await callBattleAPI(
         this.mechPrompt,
         this.battleManager.getState(),
       );
       aiSkillIndex = apiResult?.move ?? this.battleManager.getRandomAiSkill();
+      aiReasoning = apiResult?.reasoning;
     } else {
       aiSkillIndex = this.battleManager.getRandomAiSkill();
     }
@@ -1141,6 +1159,13 @@ export class BattleScene extends Phaser.Scene {
     this.setTurnIndicator(TurnPhase.AiTurn);
     for (const msg of aiLogs) {
       this.addLogMessage(msg);
+    }
+    if (aiReasoning) {
+      const truncated =
+        aiReasoning.length > 60
+          ? `${aiReasoning.slice(0, 57)}...`
+          : aiReasoning;
+      this.addLogMessage(`[EFF]AI: ${truncated}`);
     }
 
     await showSkillName(

--- a/tests/promptStrategy.test.ts
+++ b/tests/promptStrategy.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+/**
+ * Reasoning truncation logic (mirrors BattleScene inline logic).
+ * Extracted here for testability.
+ */
+function truncateReasoning(reasoning: string, maxLen = 60): string {
+  if (reasoning.length > maxLen) {
+    return `${reasoning.slice(0, maxLen - 3)}...`;
+  }
+  return reasoning;
+}
+
+/**
+ * Spinner label logic (mirrors BattleScene.showSpinner).
+ */
+function getSpinnerLabel(mechPrompt: string): string {
+  return mechPrompt.trim() ? "Analyzing strategy..." : "AI Thinking...";
+}
+
+/**
+ * Strategy indicator visibility logic (mirrors createPromptUI).
+ */
+function isStrategyActive(mechPrompt: string): boolean {
+  return mechPrompt.trim().length > 0;
+}
+
+describe("prompt strategy visibility", () => {
+  describe("reasoning truncation", () => {
+    it("should not truncate short reasoning", () => {
+      assert.equal(truncateReasoning("Use fire attack"), "Use fire attack");
+    });
+
+    it("should not truncate exactly 60 chars", () => {
+      const text = "a".repeat(60);
+      assert.equal(truncateReasoning(text), text);
+    });
+
+    it("should truncate reasoning longer than 60 chars", () => {
+      const long = "a".repeat(80);
+      const result = truncateReasoning(long);
+      assert.equal(result.length, 60);
+      assert.ok(result.endsWith("..."));
+    });
+
+    it("should preserve content before truncation point", () => {
+      const text =
+        "Using fire blast because opponent is weak to fire type attacks and this maximizes damage output significantly";
+      const result = truncateReasoning(text);
+      assert.ok(result.startsWith("Using fire blast"));
+      assert.ok(result.endsWith("..."));
+      assert.equal(result.length, 60);
+    });
+
+    it("should handle empty string", () => {
+      assert.equal(truncateReasoning(""), "");
+    });
+
+    it("should handle single character", () => {
+      assert.equal(truncateReasoning("x"), "x");
+    });
+  });
+
+  describe("spinner label", () => {
+    it("should show 'Analyzing strategy...' when prompt is set", () => {
+      assert.equal(getSpinnerLabel("Be aggressive"), "Analyzing strategy...");
+    });
+
+    it("should show 'AI Thinking...' when prompt is empty", () => {
+      assert.equal(getSpinnerLabel(""), "AI Thinking...");
+    });
+
+    it("should show 'AI Thinking...' when prompt is whitespace only", () => {
+      assert.equal(getSpinnerLabel("   "), "AI Thinking...");
+    });
+
+    it("should show 'Analyzing strategy...' for any non-empty prompt", () => {
+      assert.equal(getSpinnerLabel("x"), "Analyzing strategy...");
+    });
+  });
+
+  describe("strategy indicator", () => {
+    it("should be active when prompt has content", () => {
+      assert.equal(isStrategyActive("Be defensive"), true);
+    });
+
+    it("should be inactive when prompt is empty", () => {
+      assert.equal(isStrategyActive(""), false);
+    });
+
+    it("should be inactive when prompt is whitespace only", () => {
+      assert.equal(isStrategyActive("   \t\n  "), false);
+    });
+
+    it("should be active for single-character prompt", () => {
+      assert.equal(isStrategyActive("x"), true);
+    });
+  });
+
+  describe("reasoning log format", () => {
+    it("should format reasoning as [EFF] prefixed log message", () => {
+      const reasoning = "Fire is effective";
+      const logMsg = `[EFF]AI: ${truncateReasoning(reasoning)}`;
+      assert.equal(logMsg, "[EFF]AI: Fire is effective");
+    });
+
+    it("should format truncated reasoning correctly", () => {
+      const reasoning = "a".repeat(80);
+      const logMsg = `[EFF]AI: ${truncateReasoning(reasoning)}`;
+      assert.ok(logMsg.startsWith("[EFF]AI: "));
+      assert.ok(logMsg.endsWith("..."));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Display AI reasoning in battle log after each AI attack (truncated to 60 chars, `[EFF]AI: ...`)
- Add "⚡ Strategy Active" indicator in prompt UI when a strategy is saved
- Change spinner text to "Analyzing strategy..." when prompt is active (vs "AI Thinking..." without)
- Added 16 tests covering reasoning truncation, spinner label, strategy indicator, log format

## Test plan
- [x] 192/193 tests pass (1 pre-existing failure in assetRegistry.test.ts)
- [x] 16 new prompt strategy tests pass (truncation, spinner label, indicator, format)
- [ ] Visual verification: reasoning shows in log, indicator visible, spinner text changes

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)