### PR TITLE
feat: add lightweight core sound effects layer

### DIFF
--- a/src/scenes/BattleScene.ts
+++ b/src/scenes/BattleScene.ts
@@ -46,9 +46,22 @@ import {
   triggerInstallPrompt,
 } from "../utils/pwa";
 import {
+  initSound,
+  isMuted,
+  playAttackSound,
+  playClickSound,
+  playDefeatSound,
+  playHitSound,
+  playVictorySound,
+  resumeSound,
+  setMuted,
+} from "../utils/soundManager";
+import {
   loadMechPrompt,
+  loadSettings,
   saveBattleHistory,
   saveMechPrompt,
+  saveSettings,
 } from "../utils/storage";
 
 const COLORS = {
@@ -209,6 +222,12 @@ export class BattleScene extends Phaser.Scene {
     // Load saved prompt
     this.mechPrompt = loadMechPrompt();
 
+    // Init sound
+    initSound();
+    const settings = loadSettings();
+    setMuted(!settings.soundEnabled);
+    this.input.once("pointerdown", () => resumeSound());
+
     const { width, height } = this.scale;
     this.buildUI(width, height);
     this.createPromptUI();
@@ -235,6 +254,7 @@ export class BattleScene extends Phaser.Scene {
     this.createSkillButtons(w, h);
     this.createSpinner(w, h);
     this.createHistoryButton(w, h);
+    this.createSoundToggle(w, h);
   }
 
   // --- Background layers ---
@@ -1080,6 +1100,7 @@ export class BattleScene extends Phaser.Scene {
     if (this.isAnimating) return;
     const state = this.battleManager.getState();
     if (state.phase !== TurnPhase.PlayerTurn) return;
+    playClickSound();
 
     this.isAnimating = true;
     this.setButtonsEnabled(false);
@@ -1104,6 +1125,9 @@ export class BattleScene extends Phaser.Scene {
       SKILL_COLORS[playerSkill.type] ?? COLORS.accent,
     );
     await this.playAttackAnimation(true);
+    playAttackSound(
+      playerSkill.type as "fire" | "water" | "electric" | "defense",
+    );
     await playAttackProjectile(
       this,
       this.playerMechSprite,
@@ -1118,6 +1142,7 @@ export class BattleScene extends Phaser.Scene {
         : playerLogs.some((m: string) => m.startsWith("[RES]"))
           ? "resist"
           : "normal";
+      playHitSound();
       showDamageNumber(this, this.opponentMechSprite, playerDmg, eff);
       if (eff !== "normal") {
         showEffectivenessLabel(this, this.opponentMechSprite, eff);
@@ -1193,6 +1218,7 @@ export class BattleScene extends Phaser.Scene {
       SKILL_COLORS[aiSkill.type] ?? COLORS.accent,
     );
     await this.playAttackAnimation(false);
+    playAttackSound(aiSkill.type as "fire" | "water" | "electric" | "defense");
     await playAttackProjectile(
       this,
       this.opponentMechSprite,
@@ -1207,6 +1233,7 @@ export class BattleScene extends Phaser.Scene {
         : aiLogs.some((m: string) => m.startsWith("[RES]"))
           ? "resist"
           : "normal";
+      playHitSound();
       showDamageNumber(this, this.playerMechSprite, aiDmg, eff);
       if (eff !== "normal") {
         showEffectivenessLabel(this, this.playerMechSprite, eff);
@@ -1297,6 +1324,46 @@ export class BattleScene extends Phaser.Scene {
     });
   }
 
+  // --- Sound toggle button ---
+
+  private createSoundToggle(w: number, h: number): void {
+    const btnSize = 28;
+    const histBtnW = Math.min(w * 0.15, 100);
+    const btnX = w - histBtnW - w * 0.03 - btnSize - 8;
+    const btnY = h * 0.03;
+
+    const bg = this.add.graphics();
+    const label = this.add
+      .text(btnX + btnSize / 2, btnY + btnSize / 2, "", {
+        fontSize: `${Math.max(14, Math.floor(w * 0.02))}px`,
+      })
+      .setOrigin(0.5);
+
+    const updateVisual = () => {
+      bg.clear();
+      bg.fillStyle(COLORS.buttonBg);
+      bg.fillRoundedRect(btnX, btnY, btnSize, btnSize, 6);
+      bg.lineStyle(1, COLORS.panelBorder);
+      bg.strokeRoundedRect(btnX, btnY, btnSize, btnSize, 6);
+      label.setText(isMuted() ? "\uD83D\uDD07" : "\uD83D\uDD0A");
+    };
+    updateVisual();
+
+    const zone = this.add
+      .zone(btnX, btnY, btnSize, btnSize)
+      .setOrigin(0)
+      .setInteractive({ useHandCursor: true });
+
+    zone.on("pointerdown", () => {
+      resumeSound();
+      setMuted(!isMuted());
+      const s = loadSettings();
+      s.soundEnabled = !isMuted();
+      saveSettings(s);
+      updateVisual();
+    });
+  }
+
   // --- Save battle record ---
 
   private saveBattleRecord(won: boolean): void {
@@ -1317,6 +1384,8 @@ export class BattleScene extends Phaser.Scene {
   // --- Result screen ---
 
   private showResultScreen(won: boolean): void {
+    if (won) playVictorySound();
+    else playDefeatSound();
     this.saveBattleRecord(won);
     const state = this.battleManager.getState();
     const { width: w, height: h } = this.scale;

--- a/src/utils/soundManager.ts
+++ b/src/utils/soundManager.ts
@@ -1,0 +1,116 @@
+/**
+ * Lightweight sound effects using Web Audio API synthesis.
+ * No external audio files needed — all sounds are generated procedurally.
+ */
+
+let audioCtx: AudioContext | null = null;
+let muted = false;
+
+/** Initialize the AudioContext (call after user interaction on mobile). */
+export function initSound(): void {
+  try {
+    audioCtx = new AudioContext();
+  } catch {
+    // Web Audio API not available — degrade silently
+  }
+}
+
+/** Resume AudioContext if suspended (required after first user interaction on mobile). */
+export function resumeSound(): void {
+  if (audioCtx?.state === "suspended") {
+    audioCtx.resume();
+  }
+}
+
+export function setMuted(value: boolean): void {
+  muted = value;
+}
+
+export function isMuted(): boolean {
+  return muted;
+}
+
+function playTone(
+  frequency: number,
+  duration: number,
+  type: OscillatorType = "square",
+  volume = 0.15,
+): void {
+  if (muted || !audioCtx) return;
+
+  const osc = audioCtx.createOscillator();
+  const gain = audioCtx.createGain();
+  osc.type = type;
+  osc.frequency.value = frequency;
+  gain.gain.setValueAtTime(volume, audioCtx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(
+    0.001,
+    audioCtx.currentTime + duration,
+  );
+
+  osc.connect(gain);
+  gain.connect(audioCtx.destination);
+  osc.start();
+  osc.stop(audioCtx.currentTime + duration);
+}
+
+function playNoise(duration: number, volume = 0.1): void {
+  if (muted || !audioCtx) return;
+
+  const bufferSize = Math.floor(audioCtx.sampleRate * duration);
+  const buffer = audioCtx.createBuffer(1, bufferSize, audioCtx.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < bufferSize; i++) {
+    data[i] = Math.random() * 2 - 1;
+  }
+
+  const source = audioCtx.createBufferSource();
+  source.buffer = buffer;
+  const gain = audioCtx.createGain();
+  gain.gain.setValueAtTime(volume, audioCtx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(
+    0.001,
+    audioCtx.currentTime + duration,
+  );
+
+  source.connect(gain);
+  gain.connect(audioCtx.destination);
+  source.start();
+}
+
+/** Short click sound for button presses. */
+export function playClickSound(): void {
+  playTone(800, 0.05, "square", 0.08);
+}
+
+/** Attack sound with frequency based on skill type. */
+export function playAttackSound(
+  type: "fire" | "water" | "electric" | "defense",
+): void {
+  const freqMap = { fire: 300, water: 500, electric: 700, defense: 200 };
+  const freq = freqMap[type] ?? 400;
+  playTone(freq, 0.12, "sawtooth", 0.12);
+  playTone(freq * 1.5, 0.08, "square", 0.06);
+}
+
+/** Impact sound on hit. */
+export function playHitSound(): void {
+  playNoise(0.1, 0.15);
+  playTone(150, 0.08, "sine", 0.2);
+}
+
+/** Victory jingle — ascending tones. */
+export function playVictorySound(): void {
+  const notes = [523, 659, 784, 1047]; // C5 E5 G5 C6
+  for (let i = 0; i < notes.length; i++) {
+    setTimeout(() => playTone(notes[i], 0.15, "triangle", 0.12), i * 120);
+  }
+}
+
+/** Defeat sound — descending tones. */
+export function playDefeatSound(): void {
+  const notes = [400, 350, 300, 200]; // descending
+  for (let i = 0; i < notes.length; i++) {
+    setTimeout(() => playTone(notes[i], 0.2, "sine", 0.1), i * 150);
+  }
+}

--- a/tests/soundManager.test.ts
+++ b/tests/soundManager.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import {
+  initSound,
+  isMuted,
+  playAttackSound,
+  playClickSound,
+  playDefeatSound,
+  playHitSound,
+  playVictorySound,
+  resumeSound,
+  setMuted,
+} from "../src/utils/soundManager";
+
+describe("soundManager", () => {
+  afterEach(() => {
+    setMuted(false);
+  });
+
+  describe("mute state", () => {
+    it("should start unmuted by default", () => {
+      assert.equal(isMuted(), false);
+    });
+
+    it("should toggle mute state", () => {
+      setMuted(true);
+      assert.equal(isMuted(), true);
+      setMuted(false);
+      assert.equal(isMuted(), false);
+    });
+  });
+
+  describe("sound functions should not throw without AudioContext", () => {
+    it("initSound should not throw", () => {
+      assert.doesNotThrow(() => initSound());
+    });
+
+    it("resumeSound should not throw", () => {
+      assert.doesNotThrow(() => resumeSound());
+    });
+
+    it("playClickSound should not throw when muted", () => {
+      setMuted(true);
+      assert.doesNotThrow(() => playClickSound());
+    });
+
+    it("playAttackSound should not throw for each type", () => {
+      setMuted(true);
+      assert.doesNotThrow(() => playAttackSound("fire"));
+      assert.doesNotThrow(() => playAttackSound("water"));
+      assert.doesNotThrow(() => playAttackSound("electric"));
+      assert.doesNotThrow(() => playAttackSound("defense"));
+    });
+
+    it("playHitSound should not throw when muted", () => {
+      setMuted(true);
+      assert.doesNotThrow(() => playHitSound());
+    });
+
+    it("playVictorySound should not throw when muted", () => {
+      setMuted(true);
+      assert.doesNotThrow(() => playVictorySound());
+    });
+
+    it("playDefeatSound should not throw when muted", () => {
+      setMuted(true);
+      assert.doesNotThrow(() => playDefeatSound());
+    });
+
+    it("playClickSound should not throw without AudioContext", () => {
+      // AudioContext not available in Node test env
+      assert.doesNotThrow(() => playClickSound());
+    });
+
+    it("playAttackSound should not throw without AudioContext", () => {
+      assert.doesNotThrow(() => playAttackSound("fire"));
+    });
+
+    it("playHitSound should not throw without AudioContext", () => {
+      assert.doesNotThrow(() => playHitSound());
+    });
+
+    it("playVictorySound should not throw without AudioContext", () => {
+      assert.doesNotThrow(() => playVictorySound());
+    });
+
+    it("playDefeatSound should not throw without AudioContext", () => {
+      assert.doesNotThrow(() => playDefeatSound());
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Created `soundManager.ts` using Web Audio API (OscillatorNode + GainNode) for zero-dependency synthesized sounds
- 6 sound types: click (button), attack (per skill type frequency), hit (noise burst), victory (ascending), defeat (descending)
- Integrated into BattleScene: click on skill select, attack on animation, hit on damage, victory/defeat on result
- Added 🔊/🔇 mute toggle button next to History, persisted via GameSettings.soundEnabled
- Mobile-compatible: AudioContext resumed on first pointerdown
- 14 tests covering mute state management and graceful degradation without AudioContext

## Test plan
- [x] 222/223 tests pass (1 pre-existing failure in assetRegistry.test.ts)
- [x] 14 new sound manager tests pass
- [ ] Visual/audio verification: sounds play on battle actions, mute button works

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)