### PR TITLE
feat: make prompt strategy visibly affect battle experience

### DIFF
--- a/src/scenes/BattleScene.ts
+++ b/src/scenes/BattleScene.ts
@@ -238,6 +238,18 @@ export class BattleScene extends Phaser.Scene {
     for (const msg of state.log) {
       this.addLogMessage(msg);
     }
+
+    // Show strategy status in log
+    if (this.mechPrompt.trim()) {
+      const summary =
+        this.mechPrompt.length > 40
+          ? `${this.mechPrompt.slice(0, 37)}...`
+          : this.mechPrompt;
+      this.addLogMessage(`[EFF]Strategy: ${summary}`);
+    } else {
+      this.addLogMessage("[TURN]Tip: Save a strategy to guide your AI!");
+    }
+
     this.setTurnIndicator(state.phase);
 
     this.scale.on("resize", this.handleResize, this);
@@ -683,6 +695,7 @@ export class BattleScene extends Phaser.Scene {
       saveMechPrompt(this.mechPrompt);
       saveBtn.textContent = "Saved!";
       saveBtn.style.background = "#0a5";
+      this.addLogMessage("[EFF]Strategy updated!");
       setTimeout(() => {
         saveBtn.textContent = "Save";
         saveBtn.style.background = "#0f8";
@@ -1448,11 +1461,27 @@ export class BattleScene extends Phaser.Scene {
       .setOrigin(0.5);
     this.resultOverlay.add(summary);
 
+    // Strategy used
+    const strategyLabel = this.mechPrompt.trim()
+      ? this.mechPrompt.length > 50
+        ? `Strategy: ${this.mechPrompt.slice(0, 47)}...`
+        : `Strategy: ${this.mechPrompt}`
+      : "No strategy used";
+    const strategyColor = this.mechPrompt.trim() ? COLORS.accent : "#666666";
+    const strategyText = this.add
+      .text(w / 2, h * 0.52, strategyLabel, {
+        fontSize: `${Math.max(10, Math.floor(w * 0.015))}px`,
+        color: strategyColor,
+        wordWrap: { width: w * 0.6 },
+      })
+      .setOrigin(0.5);
+    this.resultOverlay.add(strategyText);
+
     // Play Again button
     const btnW = Math.min(w * 0.3, 200);
     const btnH = 44;
     const btnX = w / 2 - btnW / 2;
-    const btnY = h * 0.55;
+    const btnY = h * 0.58;
 
     const btnBg = this.add.graphics();
     btnBg.fillStyle(COLORS.accentHex, 1);

--- a/tests/promptVisibility.test.ts
+++ b/tests/promptVisibility.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+/**
+ * Strategy summary truncation for initial battle log (mirrors BattleScene logic).
+ */
+function getInitialStrategyLog(prompt: string): string {
+  if (prompt.trim()) {
+    const summary = prompt.length > 40 ? `${prompt.slice(0, 37)}...` : prompt;
+    return `[EFF]Strategy: ${summary}`;
+  }
+  return "[TURN]Tip: Save a strategy to guide your AI!";
+}
+
+/**
+ * Strategy label for result screen (mirrors showResultScreen logic).
+ */
+function getResultStrategyLabel(prompt: string): {
+  label: string;
+  hasStrategy: boolean;
+} {
+  if (prompt.trim()) {
+    const label =
+      prompt.length > 50
+        ? `Strategy: ${prompt.slice(0, 47)}...`
+        : `Strategy: ${prompt}`;
+    return { label, hasStrategy: true };
+  }
+  return { label: "No strategy used", hasStrategy: false };
+}
+
+describe("initial battle log strategy message", () => {
+  it("should show strategy summary when prompt is set", () => {
+    const result = getInitialStrategyLog("Be aggressive");
+    assert.equal(result, "[EFF]Strategy: Be aggressive");
+  });
+
+  it("should truncate long prompt to 40 chars", () => {
+    const long = "a".repeat(60);
+    const result = getInitialStrategyLog(long);
+    assert.ok(result.startsWith("[EFF]Strategy: "));
+    assert.ok(result.endsWith("..."));
+    // "[EFF]Strategy: " (15) + 37 + "..." (3) = 55
+    assert.equal(result.length, 55);
+  });
+
+  it("should not truncate prompt at exactly 40 chars", () => {
+    const text = "a".repeat(40);
+    const result = getInitialStrategyLog(text);
+    assert.equal(result, `[EFF]Strategy: ${text}`);
+    assert.ok(!result.endsWith("..."));
+  });
+
+  it("should show tip when prompt is empty", () => {
+    assert.equal(
+      getInitialStrategyLog(""),
+      "[TURN]Tip: Save a strategy to guide your AI!",
+    );
+  });
+
+  it("should show tip when prompt is whitespace only", () => {
+    assert.equal(
+      getInitialStrategyLog("   "),
+      "[TURN]Tip: Save a strategy to guide your AI!",
+    );
+  });
+});
+
+describe("result screen strategy label", () => {
+  it("should show strategy when prompt is set", () => {
+    const { label, hasStrategy } = getResultStrategyLabel("Be defensive");
+    assert.equal(label, "Strategy: Be defensive");
+    assert.equal(hasStrategy, true);
+  });
+
+  it("should truncate long prompt to 50 chars", () => {
+    const long = "a".repeat(80);
+    const { label, hasStrategy } = getResultStrategyLabel(long);
+    assert.ok(label.startsWith("Strategy: "));
+    assert.ok(label.endsWith("..."));
+    assert.equal(hasStrategy, true);
+    // "Strategy: " (10) + 47 + "..." (3) = 60
+    assert.equal(label.length, 60);
+  });
+
+  it("should not truncate at exactly 50 chars", () => {
+    const text = "a".repeat(50);
+    const { label } = getResultStrategyLabel(text);
+    assert.equal(label, `Strategy: ${text}`);
+  });
+
+  it("should show fallback when prompt is empty", () => {
+    const { label, hasStrategy } = getResultStrategyLabel("");
+    assert.equal(label, "No strategy used");
+    assert.equal(hasStrategy, false);
+  });
+
+  it("should show fallback when prompt is whitespace", () => {
+    const { label, hasStrategy } = getResultStrategyLabel("  \t ");
+    assert.equal(label, "No strategy used");
+    assert.equal(hasStrategy, false);
+  });
+});
+
+describe("strategy update log message", () => {
+  it("should use [EFF] prefix for strategy update", () => {
+    const msg = "[EFF]Strategy updated!";
+    assert.ok(msg.startsWith("[EFF]"));
+    assert.ok(msg.includes("updated"));
+  });
+});


### PR DESCRIPTION
## Summary
- Show strategy summary in initial battle log (truncated to 40 chars, or guidance tip if empty)
- Show strategy used on result screen below battle stats (truncated to 50 chars, or "No strategy used")
- Log "Strategy updated!" to battle log when Save is clicked
- 11 tests covering strategy log, result label, truncation, empty/whitespace

## Test plan
- [x] 233/234 tests pass (1 pre-existing failure in assetRegistry.test.ts)
- [x] 11 new prompt visibility tests pass
- [ ] Visual verification: strategy in log, result screen, update feedback

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)