### PR TITLE
feat: add mech information cards and unit identity UI

### DIFF
--- a/src/data/mechs.ts
+++ b/src/data/mechs.ts
@@ -7,6 +7,9 @@ export const PLAYER_MECH: Mech = {
   type: MechType.Fire,
   hp: 100,
   maxHp: 100,
+  codename: "FALCON UNIT",
+  role: "Assault",
+  bio: "Agile fire-type striker built for aggressive offense.",
   skills: [
     { name: "Fire Blast", type: MechType.Fire, damage: 40 },
     { name: "Water Cannon", type: MechType.Water, damage: 30 },
@@ -20,6 +23,9 @@ export const OPPONENT_MECH: Mech = {
   type: MechType.Water,
   hp: 100,
   maxHp: 100,
+  codename: "VENOM BATTALION",
+  role: "Tank",
+  bio: "Heavy water-type defender with punishing counter-attacks.",
   skills: [
     { name: "Water Cannon", type: MechType.Water, damage: 30 },
     { name: "Fire Blast", type: MechType.Fire, damage: 40 },

--- a/src/scenes/BattleScene.ts
+++ b/src/scenes/BattleScene.ts
@@ -341,11 +341,16 @@ export class BattleScene extends Phaser.Scene {
     const textOffsetX = showPortrait ? portraitSize + 12 : 10;
 
     this.add
-      .text(panelX + textOffsetX, panelY + 6, "Enemy Mech  Lv.5", {
-        fontSize: `${Math.max(11, Math.floor(w * 0.018))}px`,
-        color: COLORS.text,
-        fontStyle: "bold",
-      })
+      .text(
+        panelX + textOffsetX,
+        panelY + 6,
+        `${OPPONENT_MECH.codename ?? OPPONENT_MECH.name}  Lv.5`,
+        {
+          fontSize: `${Math.max(11, Math.floor(w * 0.018))}px`,
+          color: COLORS.text,
+          fontStyle: "bold",
+        },
+      )
       .setOrigin(0, 0);
 
     // HP bar
@@ -425,11 +430,16 @@ export class BattleScene extends Phaser.Scene {
     }
 
     this.add
-      .text(panelX + 10, panelY + 6, "Your Mech  Lv.5", {
-        fontSize: `${Math.max(11, Math.floor(w * 0.018))}px`,
-        color: COLORS.text,
-        fontStyle: "bold",
-      })
+      .text(
+        panelX + 10,
+        panelY + 6,
+        `${PLAYER_MECH.codename ?? PLAYER_MECH.name}  Lv.5`,
+        {
+          fontSize: `${Math.max(11, Math.floor(w * 0.018))}px`,
+          color: COLORS.text,
+          fontStyle: "bold",
+        },
+      )
       .setOrigin(0, 0);
 
     // HP bar

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -100,21 +100,32 @@ export class LobbyScene extends Phaser.Scene {
         img.setDisplaySize(portraitSize, portraitSize);
       }
     }
+    const playerNameY = centerY + portraitSize / 2;
     this.add
-      .text(playerX, centerY + portraitSize / 2, PLAYER_MECH.name, {
+      .text(playerX, playerNameY, PLAYER_MECH.codename ?? PLAYER_MECH.name, {
         fontSize,
         color: TYPE_COLORS[PLAYER_MECH.type] ?? COLORS.text,
         fontStyle: "bold",
       })
       .setOrigin(0.5, 0);
-    this.add
-      .text(
-        playerX,
-        centerY + portraitSize / 2 + 18,
-        PLAYER_MECH.type.toUpperCase(),
-        { fontSize: subFontSize, color: COLORS.dimText },
-      )
-      .setOrigin(0.5, 0);
+    if (PLAYER_MECH.role) {
+      this.add
+        .text(playerX, playerNameY + 16, PLAYER_MECH.role, {
+          fontSize: subFontSize,
+          color: COLORS.dimText,
+        })
+        .setOrigin(0.5, 0);
+    }
+    if (PLAYER_MECH.bio) {
+      this.add
+        .text(playerX, playerNameY + 30, PLAYER_MECH.bio, {
+          fontSize: `${Math.max(9, Math.floor(w * 0.012))}px`,
+          color: "#777777",
+          wordWrap: { width: panelW * 0.35 },
+          align: "center",
+        })
+        .setOrigin(0.5, 0);
+    }
 
     // VS
     this.add
@@ -135,21 +146,37 @@ export class LobbyScene extends Phaser.Scene {
         img.setDisplaySize(portraitSize, portraitSize);
       }
     }
-    this.add
-      .text(opponentX, centerY + portraitSize / 2, OPPONENT_MECH.name, {
-        fontSize,
-        color: TYPE_COLORS[OPPONENT_MECH.type] ?? COLORS.text,
-        fontStyle: "bold",
-      })
-      .setOrigin(0.5, 0);
+    const opponentNameY = centerY + portraitSize / 2;
     this.add
       .text(
         opponentX,
-        centerY + portraitSize / 2 + 18,
-        OPPONENT_MECH.type.toUpperCase(),
-        { fontSize: subFontSize, color: COLORS.dimText },
+        opponentNameY,
+        OPPONENT_MECH.codename ?? OPPONENT_MECH.name,
+        {
+          fontSize,
+          color: TYPE_COLORS[OPPONENT_MECH.type] ?? COLORS.text,
+          fontStyle: "bold",
+        },
       )
       .setOrigin(0.5, 0);
+    if (OPPONENT_MECH.role) {
+      this.add
+        .text(opponentX, opponentNameY + 16, OPPONENT_MECH.role, {
+          fontSize: subFontSize,
+          color: COLORS.dimText,
+        })
+        .setOrigin(0.5, 0);
+    }
+    if (OPPONENT_MECH.bio) {
+      this.add
+        .text(opponentX, opponentNameY + 30, OPPONENT_MECH.bio, {
+          fontSize: `${Math.max(9, Math.floor(w * 0.012))}px`,
+          color: "#777777",
+          wordWrap: { width: panelW * 0.35 },
+          align: "center",
+        })
+        .setOrigin(0.5, 0);
+    }
   }
 
   private drawSkillPreview(w: number, h: number): void {

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -30,6 +30,9 @@ export interface Mech {
   hp: number;
   maxHp: number;
   skills: Skill[];
+  codename?: string;
+  role?: string;
+  bio?: string;
 }
 
 export interface BattleState {

--- a/tests/mechIdentity.test.ts
+++ b/tests/mechIdentity.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { OPPONENT_MECH, PLAYER_MECH } from "../src/data/mechs";
+
+describe("mech identity fields", () => {
+  it("PLAYER_MECH should have codename FALCON UNIT", () => {
+    assert.equal(PLAYER_MECH.codename, "FALCON UNIT");
+  });
+
+  it("OPPONENT_MECH should have codename VENOM BATTALION", () => {
+    assert.equal(OPPONENT_MECH.codename, "VENOM BATTALION");
+  });
+
+  it("PLAYER_MECH should have role Assault", () => {
+    assert.equal(PLAYER_MECH.role, "Assault");
+  });
+
+  it("OPPONENT_MECH should have role Tank", () => {
+    assert.equal(OPPONENT_MECH.role, "Tank");
+  });
+
+  it("both mechs should have bio strings", () => {
+    assert.ok(PLAYER_MECH.bio && PLAYER_MECH.bio.length > 0);
+    assert.ok(OPPONENT_MECH.bio && OPPONENT_MECH.bio.length > 0);
+  });
+
+  it("codenames should be different", () => {
+    assert.notEqual(PLAYER_MECH.codename, OPPONENT_MECH.codename);
+  });
+
+  it("roles should be different", () => {
+    assert.notEqual(PLAYER_MECH.role, OPPONENT_MECH.role);
+  });
+});
+
+describe("mech HUD display name", () => {
+  function getHudName(mech: { codename?: string; name: string }): string {
+    return `${mech.codename ?? mech.name}  Lv.5`;
+  }
+
+  it("should use codename when available", () => {
+    assert.equal(getHudName(PLAYER_MECH), "FALCON UNIT  Lv.5");
+  });
+
+  it("should fall back to name when no codename", () => {
+    assert.equal(getHudName({ name: "Generic" }), "Generic  Lv.5");
+  });
+
+  it("opponent HUD should show VENOM BATTALION", () => {
+    assert.equal(getHudName(OPPONENT_MECH), "VENOM BATTALION  Lv.5");
+  });
+});
+
+describe("mech info card display", () => {
+  function getCardName(mech: { codename?: string; name: string }): string {
+    return mech.codename ?? mech.name;
+  }
+
+  it("should prefer codename for card title", () => {
+    assert.equal(getCardName(PLAYER_MECH), "FALCON UNIT");
+  });
+
+  it("should fall back to name if no codename", () => {
+    assert.equal(getCardName({ name: "Test" }), "Test");
+  });
+});


### PR DESCRIPTION
## Summary
- Extended Mech interface with optional `codename`, `role`, `bio` fields (backward-compatible)
- FALCON UNIT (Assault) for player mech, VENOM BATTALION (Tank) for enemy mech
- LobbyScene mech preview now shows codename, role, and bio below portrait
- BattleScene HUD uses codename instead of generic "Your Mech" / "Enemy Mech"
- 12 new tests covering identity fields, HUD name, card name display logic

## Test plan
- [x] 270/271 tests pass (1 pre-existing failure in assetRegistry.test.ts)
- [x] 12 new mech identity tests pass
- [ ] Visual verification: lobby info cards, HUD codenames

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)