### PR TITLE
feat: add selectable player mech roster

### DIFF
--- a/src/data/mechs.ts
+++ b/src/data/mechs.ts
@@ -2,21 +2,56 @@
 
 import { type Mech, MechType } from "../types/game";
 
-export const PLAYER_MECH: Mech = {
-  name: "Your Mech",
-  type: MechType.Fire,
-  hp: 100,
-  maxHp: 100,
-  codename: "FALCON UNIT",
-  role: "Assault",
-  bio: "Agile fire-type striker built for aggressive offense.",
-  skills: [
-    { name: "Fire Blast", type: MechType.Fire, damage: 40 },
-    { name: "Water Cannon", type: MechType.Water, damage: 30 },
-    { name: "Thunder Shock", type: MechType.Electric, damage: 25 },
-    { name: "Iron Defense", type: "defense", damage: 0 },
-  ],
-};
+export const MECH_ROSTER: Mech[] = [
+  {
+    name: "Your Mech",
+    type: MechType.Fire,
+    hp: 100,
+    maxHp: 100,
+    codename: "FALCON UNIT",
+    role: "Assault",
+    bio: "Agile fire-type striker built for aggressive offense.",
+    skills: [
+      { name: "Fire Blast", type: MechType.Fire, damage: 40 },
+      { name: "Water Cannon", type: MechType.Water, damage: 30 },
+      { name: "Thunder Shock", type: MechType.Electric, damage: 25 },
+      { name: "Iron Defense", type: "defense", damage: 0 },
+    ],
+  },
+  {
+    name: "Your Mech",
+    type: MechType.Water,
+    hp: 120,
+    maxHp: 120,
+    codename: "HYDRA SENTINEL",
+    role: "Support",
+    bio: "Resilient water-type defender with healing capabilities.",
+    skills: [
+      { name: "Water Cannon", type: MechType.Water, damage: 35 },
+      { name: "Fire Blast", type: MechType.Fire, damage: 25 },
+      { name: "Thunder Shock", type: MechType.Electric, damage: 20 },
+      { name: "Iron Defense", type: "defense", damage: 0 },
+    ],
+  },
+  {
+    name: "Your Mech",
+    type: MechType.Electric,
+    hp: 90,
+    maxHp: 90,
+    codename: "VOLT STRIKER",
+    role: "Specialist",
+    bio: "High-speed electric mech with devastating burst damage.",
+    skills: [
+      { name: "Thunder Shock", type: MechType.Electric, damage: 45 },
+      { name: "Fire Blast", type: MechType.Fire, damage: 30 },
+      { name: "Water Cannon", type: MechType.Water, damage: 20 },
+      { name: "Iron Defense", type: "defense", damage: 0 },
+    ],
+  },
+];
+
+/** Default player mech (first in roster). */
+export const PLAYER_MECH: Mech = MECH_ROSTER[0];
 
 export const OPPONENT_MECH: Mech = {
   name: "Enemy Mech",

--- a/src/scenes/BattleScene.ts
+++ b/src/scenes/BattleScene.ts
@@ -5,7 +5,7 @@
 import Phaser from "phaser";
 import { callBattleAPI } from "../api/battleClient";
 import { ASSET_REGISTRY } from "../assets";
-import { type MechType, TurnPhase } from "../types/game";
+import { type Mech, type MechType, TurnPhase } from "../types/game";
 import type { BattleRecord } from "../types/storage";
 import { BattleManager } from "../utils/BattleManager";
 import { getEffectiveness } from "../utils/BattleManager";
@@ -157,6 +157,9 @@ export class BattleScene extends Phaser.Scene {
   private promptContainer?: HTMLDivElement;
   private mechPrompt = "";
 
+  // Selected player mech (set via init data or default)
+  private playerMech: Mech = PLAYER_MECH;
+
   // PWA banners (DOM elements)
   private offlineBanner?: HTMLDivElement;
   private updateBanner?: HTMLDivElement;
@@ -167,6 +170,10 @@ export class BattleScene extends Phaser.Scene {
   constructor() {
     super({ key: "BattleScene" });
     console.log("[BattleScene] constructor called");
+  }
+
+  init(data?: { selectedMech?: Mech }): void {
+    this.playerMech = data?.selectedMech ?? PLAYER_MECH;
   }
 
   preload(): void {
@@ -188,7 +195,7 @@ export class BattleScene extends Phaser.Scene {
     console.log("[BattleScene] create() start");
     this.battleManager = new BattleManager();
     this.battleManager.initBattle(
-      JSON.parse(JSON.stringify(PLAYER_MECH)),
+      JSON.parse(JSON.stringify(this.playerMech)),
       JSON.parse(JSON.stringify(OPPONENT_MECH)),
     );
 
@@ -397,7 +404,7 @@ export class BattleScene extends Phaser.Scene {
 
     this.playerMechSprite = createMechSprite(
       this,
-      PLAYER_MECH.type,
+      this.playerMech.type,
       spriteX,
       spriteY,
       spriteW,
@@ -421,7 +428,7 @@ export class BattleScene extends Phaser.Scene {
       const portraitX = panelX + panelW - 6 - portraitSize / 2;
       const portraitY = panelY + panelH / 2;
       this.playerPortrait = this.addPortrait(
-        PLAYER_MECH.type,
+        this.playerMech.type,
         this.playerPortraitState,
         portraitX,
         portraitY,
@@ -433,7 +440,7 @@ export class BattleScene extends Phaser.Scene {
       .text(
         panelX + 10,
         panelY + 6,
-        `${PLAYER_MECH.codename ?? PLAYER_MECH.name}  Lv.5`,
+        `${this.playerMech.codename ?? this.playerMech.name}  Lv.5`,
         {
           fontSize: `${Math.max(11, Math.floor(w * 0.018))}px`,
           color: COLORS.text,
@@ -982,7 +989,7 @@ export class BattleScene extends Phaser.Scene {
 
     if (newState === currentState || !portrait) return;
 
-    const mechType = isOpponent ? OPPONENT_MECH.type : PLAYER_MECH.type;
+    const mechType = isOpponent ? OPPONENT_MECH.type : this.playerMech.type;
     const states = PORTRAIT_TEXTURE_KEYS[mechType];
     if (!states) return;
     const entry = states[newState];
@@ -1126,7 +1133,7 @@ export class BattleScene extends Phaser.Scene {
     const afterPlayer = this.battleManager.executePlayerAttack(index);
     const playerLogs = afterPlayer.log.slice(prevLogLen);
 
-    const playerSkill = PLAYER_MECH.skills[index];
+    const playerSkill = this.playerMech.skills[index];
 
     this.setTurnIndicator(TurnPhase.PlayerTurn);
     for (const msg of playerLogs) {
@@ -1387,7 +1394,7 @@ export class BattleScene extends Phaser.Scene {
     const record: BattleRecord = {
       id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       timestamp: Date.now(),
-      playerMechType: PLAYER_MECH.type,
+      playerMechType: this.playerMech.type,
       opponentMechType: OPPONENT_MECH.type,
       result: won ? "win" : "loss",
       turns: state.turnCount,
@@ -1601,7 +1608,7 @@ export class BattleScene extends Phaser.Scene {
     this.playerPortraitState = "normal";
 
     this.battleManager.initBattle(
-      JSON.parse(JSON.stringify(PLAYER_MECH)),
+      JSON.parse(JSON.stringify(this.playerMech)),
       JSON.parse(JSON.stringify(OPPONENT_MECH)),
     );
 

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -4,7 +4,7 @@
 
 import Phaser from "phaser";
 import { ASSET_REGISTRY, preloadAllAssets } from "../assets";
-import { OPPONENT_MECH, PLAYER_MECH } from "../data/mechs";
+import { MECH_ROSTER, OPPONENT_MECH } from "../data/mechs";
 import { loadMechPrompt } from "../utils/storage";
 
 const COLORS = {
@@ -31,6 +31,8 @@ const TYPE_COLORS: Record<string, string> = {
 };
 
 export class LobbyScene extends Phaser.Scene {
+  private selectedIndex = 0;
+
   constructor() {
     super({ key: "LobbyScene" });
   }
@@ -40,9 +42,14 @@ export class LobbyScene extends Phaser.Scene {
   }
 
   create(): void {
+    this.selectedIndex = 0;
     const { width: w, height: h } = this.scale;
     this.buildUI(w, h);
     this.scale.on("resize", this.handleResize, this);
+  }
+
+  private selectedMech() {
+    return MECH_ROSTER[this.selectedIndex];
   }
 
   private buildUI(w: number, h: number): void {
@@ -60,6 +67,9 @@ export class LobbyScene extends Phaser.Scene {
       })
       .setOrigin(0.5);
 
+    // Mech roster selection
+    this.drawRosterSelection(w, h);
+
     // VS section
     this.drawMechPreview(w, h);
 
@@ -71,6 +81,50 @@ export class LobbyScene extends Phaser.Scene {
 
     // Buttons
     this.drawButtons(w, h);
+  }
+
+  private drawRosterSelection(w: number, h: number): void {
+    const cardW = Math.min(w * 0.25, 120);
+    const cardH = 32;
+    const gap = 8;
+    const totalW = MECH_ROSTER.length * (cardW + gap) - gap;
+    const startX = (w - totalW) / 2;
+    const y = h * 0.12;
+    const fontSize = `${Math.max(10, Math.floor(w * 0.014))}px`;
+
+    for (let i = 0; i < MECH_ROSTER.length; i++) {
+      const mech = MECH_ROSTER[i];
+      const x = startX + i * (cardW + gap);
+      const isSelected = i === this.selectedIndex;
+
+      const bg = this.add.graphics();
+      bg.fillStyle(isSelected ? 0x334433 : COLORS.buttonBg, 1);
+      bg.fillRoundedRect(x, y, cardW, cardH, 6);
+      bg.lineStyle(2, isSelected ? COLORS.accentHex : COLORS.panelBorder);
+      bg.strokeRoundedRect(x, y, cardW, cardH, 6);
+
+      const label = mech.codename ?? mech.name;
+      const color = isSelected
+        ? COLORS.accent
+        : (TYPE_COLORS[mech.type] ?? COLORS.text);
+      this.add
+        .text(x + cardW / 2, y + cardH / 2, label, {
+          fontSize,
+          color,
+          fontStyle: isSelected ? "bold" : "normal",
+        })
+        .setOrigin(0.5);
+
+      const zone = this.add
+        .zone(x, y, cardW, cardH)
+        .setOrigin(0)
+        .setInteractive({ useHandCursor: true });
+
+      zone.on("pointerdown", () => {
+        this.selectedIndex = i;
+        this.buildUI(w, h);
+      });
+    }
   }
 
   private drawMechPreview(w: number, h: number): void {
@@ -92,7 +146,7 @@ export class LobbyScene extends Phaser.Scene {
 
     // Player side
     const playerX = panelX + panelW * 0.25;
-    const playerPortrait = ASSET_REGISTRY.portraits[PLAYER_MECH.type];
+    const playerPortrait = ASSET_REGISTRY.portraits[this.selectedMech().type];
     if (playerPortrait) {
       const key = playerPortrait.normal.key;
       if (this.textures.exists(key)) {
@@ -102,23 +156,28 @@ export class LobbyScene extends Phaser.Scene {
     }
     const playerNameY = centerY + portraitSize / 2;
     this.add
-      .text(playerX, playerNameY, PLAYER_MECH.codename ?? PLAYER_MECH.name, {
-        fontSize,
-        color: TYPE_COLORS[PLAYER_MECH.type] ?? COLORS.text,
-        fontStyle: "bold",
-      })
+      .text(
+        playerX,
+        playerNameY,
+        this.selectedMech().codename ?? this.selectedMech().name,
+        {
+          fontSize,
+          color: TYPE_COLORS[this.selectedMech().type] ?? COLORS.text,
+          fontStyle: "bold",
+        },
+      )
       .setOrigin(0.5, 0);
-    if (PLAYER_MECH.role) {
+    if (this.selectedMech().role) {
       this.add
-        .text(playerX, playerNameY + 16, PLAYER_MECH.role, {
+        .text(playerX, playerNameY + 16, this.selectedMech().role as string, {
           fontSize: subFontSize,
           color: COLORS.dimText,
         })
         .setOrigin(0.5, 0);
     }
-    if (PLAYER_MECH.bio) {
+    if (this.selectedMech().bio) {
       this.add
-        .text(playerX, playerNameY + 30, PLAYER_MECH.bio, {
+        .text(playerX, playerNameY + 30, this.selectedMech().bio as string, {
           fontSize: `${Math.max(9, Math.floor(w * 0.012))}px`,
           color: "#777777",
           wordWrap: { width: panelW * 0.35 },
@@ -194,8 +253,8 @@ export class LobbyScene extends Phaser.Scene {
       })
       .setOrigin(0, 0);
 
-    for (let i = 0; i < PLAYER_MECH.skills.length; i++) {
-      const skill = PLAYER_MECH.skills[i];
+    for (let i = 0; i < this.selectedMech().skills.length; i++) {
+      const skill = this.selectedMech().skills[i];
       const y = panelY + lineH * (i + 1);
       const typeColor = TYPE_COLORS[skill.type] ?? COLORS.defense;
       const dmgText =
@@ -290,7 +349,9 @@ export class LobbyScene extends Phaser.Scene {
     });
     startZone.on("pointerdown", () => {
       this.scale.off("resize", this.handleResize, this);
-      this.scene.start("BattleScene");
+      this.scene.start("BattleScene", {
+        selectedMech: this.selectedMech(),
+      });
     });
 
     // History button

--- a/tests/mechRoster.test.ts
+++ b/tests/mechRoster.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { MECH_ROSTER, OPPONENT_MECH, PLAYER_MECH } from "../src/data/mechs";
+import { MechType } from "../src/types/game";
+
+describe("MECH_ROSTER", () => {
+  it("should contain at least 3 mechs", () => {
+    assert.ok(MECH_ROSTER.length >= 3);
+  });
+
+  it("each mech should have required fields", () => {
+    for (const mech of MECH_ROSTER) {
+      assert.ok(mech.name);
+      assert.ok(mech.type);
+      assert.equal(typeof mech.hp, "number");
+      assert.equal(typeof mech.maxHp, "number");
+      assert.ok(mech.skills.length >= 1);
+    }
+  });
+
+  it("should contain all three types", () => {
+    const types = new Set(MECH_ROSTER.map((m) => m.type));
+    assert.ok(types.has(MechType.Fire));
+    assert.ok(types.has(MechType.Water));
+    assert.ok(types.has(MechType.Electric));
+  });
+
+  it("each mech should have 4 skills", () => {
+    for (const mech of MECH_ROSTER) {
+      assert.equal(mech.skills.length, 4);
+    }
+  });
+
+  it("each mech should have codename and role", () => {
+    for (const mech of MECH_ROSTER) {
+      assert.ok(mech.codename, `${mech.type} mech missing codename`);
+      assert.ok(mech.role, `${mech.type} mech missing role`);
+    }
+  });
+
+  it("codenames should be unique", () => {
+    const names = MECH_ROSTER.map((m) => m.codename);
+    assert.equal(new Set(names).size, names.length);
+  });
+
+  it("all mechs should have distinct types", () => {
+    const types = MECH_ROSTER.map((m) => m.type);
+    assert.equal(new Set(types).size, types.length);
+  });
+});
+
+describe("PLAYER_MECH default", () => {
+  it("should be the first roster mech", () => {
+    assert.deepStrictEqual(PLAYER_MECH, MECH_ROSTER[0]);
+  });
+});
+
+describe("OPPONENT_MECH", () => {
+  it("should have Water type", () => {
+    assert.equal(OPPONENT_MECH.type, MechType.Water);
+  });
+
+  it("should have VENOM BATTALION codename", () => {
+    assert.equal(OPPONENT_MECH.codename, "VENOM BATTALION");
+  });
+});
+
+describe("mech roster balance", () => {
+  it("FALCON UNIT (Fire) should have highest single-hit damage", () => {
+    const falcon = MECH_ROSTER.find((m) => m.codename === "FALCON UNIT");
+    assert.ok(falcon);
+    const maxDmg = Math.max(...falcon.skills.map((s) => s.damage));
+    assert.equal(maxDmg, 40);
+  });
+
+  it("HYDRA SENTINEL (Water) should have highest HP", () => {
+    const hydra = MECH_ROSTER.find((m) => m.codename === "HYDRA SENTINEL");
+    assert.ok(hydra);
+    assert.ok(hydra.maxHp >= 120);
+  });
+
+  it("VOLT STRIKER (Electric) should have highest primary skill damage", () => {
+    const volt = MECH_ROSTER.find((m) => m.codename === "VOLT STRIKER");
+    assert.ok(volt);
+    const maxDmg = Math.max(...volt.skills.map((s) => s.damage));
+    assert.equal(maxDmg, 45);
+  });
+
+  it("VOLT STRIKER should have lowest HP to balance burst damage", () => {
+    const volt = MECH_ROSTER.find((m) => m.codename === "VOLT STRIKER");
+    assert.ok(volt);
+    const minHp = Math.min(...MECH_ROSTER.map((m) => m.maxHp));
+    assert.equal(volt.maxHp, minHp);
+  });
+});


### PR DESCRIPTION
## Summary
- Created `MECH_ROSTER` with 3 distinct mechs: FALCON UNIT (Fire/Assault), HYDRA SENTINEL (Water/Support/120HP), VOLT STRIKER (Electric/Specialist/45 burst)
- Added roster selection cards in LobbyScene (horizontal row with highlight)
- BattleScene accepts selected mech via `init(data)`, all `PLAYER_MECH` refs → `this.playerMech`
- Selected mech passed from LobbyScene to BattleScene via `scene.start` data
- 14 new tests covering roster composition, types, balance, uniqueness

## Test plan
- [x] 284/285 tests pass (1 pre-existing failure in assetRegistry.test.ts)
- [x] 14 new mech roster tests pass
- [ ] Visual verification: roster cards selectable, preview updates, battle uses selected mech

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)