### PR TITLE
feat: turn battle log into real combat event feed

### DIFF
--- a/src/scenes/BattleScene.ts
+++ b/src/scenes/BattleScene.ts
@@ -529,7 +529,7 @@ export class BattleScene extends Phaser.Scene {
     const logX = w * 0.03;
     const logY = h * 0.37;
     const logW = w * 0.44;
-    const logH = Math.min(h * 0.25, h - logY - 10);
+    const logH = Math.min(h * 0.35, h - logY - 10);
 
     const bg = this.add.graphics();
     bg.fillStyle(0x1a1a2e, 0.92);

--- a/src/utils/BattleManager.ts
+++ b/src/utils/BattleManager.ts
@@ -70,7 +70,7 @@ export class BattleManager {
       this.state.player,
       this.state.opponent,
     );
-    this.addLog(`${this.state.player.name} used ${playerSkill.name}!`);
+    this.addLog(`[EFF]${this.state.player.name} used ${playerSkill.name}!`);
     this.updateHP("opponent", playerDmg);
     if (playerSkill.type === "defense" || playerDmg === 0) {
       this.addLog(`[EFF]${this.state.player.name} raised defense!`);
@@ -102,7 +102,7 @@ export class BattleManager {
       this.state.opponent,
       this.state.player,
     );
-    this.addLog(`${this.state.opponent.name} used ${aiSkill.name}!`);
+    this.addLog(`[EFF]${this.state.opponent.name} used ${aiSkill.name}!`);
     this.updateHP("player", aiDmg);
     if (aiSkill.type === "defense" || aiDmg === 0) {
       this.addLog(`[EFF]${this.state.opponent.name} raised defense!`);

--- a/src/utils/logColors.ts
+++ b/src/utils/logColors.ts
@@ -13,7 +13,7 @@ export const LOG_COLORS: Record<string, string> = {
   "[RES]": "#66ccff", // blue for not very effective
 };
 
-export const LOG_MAX_LINES = 8;
+export const LOG_MAX_LINES = 12;
 
 export interface ParsedLogMessage {
   displayMsg: string;

--- a/tests/battleClient.test.ts
+++ b/tests/battleClient.test.ts
@@ -35,7 +35,7 @@ function makeGameState(overrides?: Partial<BattleState>): BattleState {
       "[TURN]--- Battle Start ---",
       "[EFF]PlayerMech vs EnemyMech",
       "Choose your attack!",
-      "PlayerMech used Fire Blast!",
+      "[EFF]PlayerMech used Fire Blast!",
     ],
     turnCount: 1,
     winner: null,
@@ -81,7 +81,7 @@ describe("callBattleAPI", () => {
     assert.equal(body.mechPrompt, "test prompt");
     assert.equal(body.gameState.playerHP, 80);
     assert.equal(body.gameState.opponentHP, 60);
-    assert.equal(body.gameState.lastMove, "PlayerMech used Fire Blast!");
+    assert.equal(body.gameState.lastMove, "[EFF]PlayerMech used Fire Blast!");
   });
 
   it("should return null after max retries on network error", async () => {
@@ -140,9 +140,9 @@ describe("callBattleAPI", () => {
         "[TURN]--- Battle Start ---",
         "[EFF]PlayerMech vs EnemyMech",
         "Choose your attack!",
-        "PlayerMech used Fire Blast!",
+        "[EFF]PlayerMech used Fire Blast!",
         "It's not very effective...",
-        "EnemyMech used Water Cannon!",
+        "[EFF]EnemyMech used Water Cannon!",
       ],
     });
 
@@ -151,6 +151,6 @@ describe("callBattleAPI", () => {
     const body = JSON.parse(
       fetchMock.mock.calls[0].arguments[1]?.body as string,
     );
-    assert.equal(body.gameState.lastMove, "EnemyMech used Water Cannon!");
+    assert.equal(body.gameState.lastMove, "[EFF]EnemyMech used Water Cannon!");
   });
 });

--- a/tests/battleReplay.test.ts
+++ b/tests/battleReplay.test.ts
@@ -20,7 +20,10 @@ function makeRecord(overrides?: Partial<BattleRecord>): BattleRecord {
 describe("BattleRecord battleLog field", () => {
   it("should support optional battleLog", () => {
     const record = makeRecord({
-      battleLog: ["[TURN]--- Battle Start ---", "Your Mech used Fire Blast!"],
+      battleLog: [
+        "[TURN]--- Battle Start ---",
+        "[EFF]Your Mech used Fire Blast!",
+      ],
     });
     assert.ok(Array.isArray(record.battleLog));
     assert.equal(record.battleLog?.length, 2);
@@ -34,7 +37,7 @@ describe("BattleRecord battleLog field", () => {
   it("should preserve log message order", () => {
     const logs = [
       "[TURN]--- Battle Start ---",
-      "Your Mech used Fire Blast!",
+      "[EFF]Your Mech used Fire Blast!",
       "[DMG]Enemy took 40 damage! HP: 60/100",
       "[SUP]It's super effective!",
     ];
@@ -79,8 +82,8 @@ describe("replay log parsing", () => {
   });
 
   it("should handle unprefixed messages with accent color", () => {
-    const { displayMsg, color } = parseLogMessage("Your Mech used Fire Blast!");
-    assert.equal(displayMsg, "Your Mech used Fire Blast!");
+    const { displayMsg, color } = parseLogMessage("Choose your attack!");
+    assert.equal(displayMsg, "Choose your attack!");
     assert.equal(color, "#00ff88");
   });
 });
@@ -107,7 +110,7 @@ describe("replay key event detection", () => {
   });
 
   it("should not mark normal attack as key event", () => {
-    assert.ok(!isKeyEvent("Your Mech used Fire Blast!"));
+    assert.ok(!isKeyEvent("[EFF]Your Mech used Fire Blast!"));
   });
 
   it("should not mark damage log as key event", () => {

--- a/tests/logColors.test.ts
+++ b/tests/logColors.test.ts
@@ -73,7 +73,7 @@ describe("LOG_COLORS", () => {
 });
 
 describe("LOG_MAX_LINES", () => {
-  it("should be 8", () => {
-    assert.equal(LOG_MAX_LINES, 8);
+  it("should be 12", () => {
+    assert.equal(LOG_MAX_LINES, 12);
   });
 });


### PR DESCRIPTION
## Summary
- Increased `LOG_MAX_LINES` from 8 to 12, expanded panel height (0.25→0.35) for more visible history
- Added `[EFF]` prefix to skill usage messages for green color highlighting
- All combat events now have distinct color coding: turns (gray), skills (green), damage (gold), super effective (red), resisted (blue)
- Updated affected tests for new log format and max lines value

## Test plan
- [x] 326/327 tests pass (1 pre-existing failure in assetRegistry.test.ts)
- [x] Updated logColors, battleReplay, battleClient tests for new format
- [ ] Visual verification: more log lines visible, skill messages highlighted

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)