### PR TITLE
feat: add first-run initial mech binding

### DIFF
--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -7,8 +7,11 @@ import { ASSET_REGISTRY, preloadAllAssets } from "../assets";
 import { MECH_ROSTER, OPPONENT_MECH } from "../data/mechs";
 import {
   hasSeenOnboarding,
+  hasStarterMech,
   loadMechPrompt,
+  loadStarterMech,
   markOnboardingSeen,
+  saveStarterMech,
 } from "../utils/storage";
 
 const COLORS = {
@@ -46,12 +49,14 @@ export class LobbyScene extends Phaser.Scene {
   }
 
   create(): void {
-    this.selectedIndex = 0;
+    this.selectedIndex = hasStarterMech() ? loadStarterMech() : 0;
     const { width: w, height: h } = this.scale;
     this.buildUI(w, h);
     this.scale.on("resize", this.handleResize, this);
 
-    if (!hasSeenOnboarding()) {
+    if (!hasStarterMech()) {
+      this.showMechBinding();
+    } else if (!hasSeenOnboarding()) {
       this.showOnboarding();
     }
   }
@@ -429,6 +434,179 @@ export class LobbyScene extends Phaser.Scene {
     helpZone.on("pointerdown", () => {
       this.showOnboarding();
     });
+  }
+
+  // --- Mech Binding ---
+
+  private showMechBinding(): void {
+    const { width: w, height: h } = this.scale;
+    const overlay = this.add.container(0, 0);
+
+    // Backdrop
+    const bg = this.add.graphics();
+    bg.fillStyle(0x000000, 0.9);
+    bg.fillRect(0, 0, w, h);
+    overlay.add(bg);
+
+    // Title
+    overlay.add(
+      this.add
+        .text(w / 2, h * 0.06, "CHOOSE YOUR MECH", {
+          fontSize: `${Math.max(20, Math.floor(w * 0.035))}px`,
+          color: COLORS.accent,
+          fontStyle: "bold",
+        })
+        .setOrigin(0.5),
+    );
+
+    overlay.add(
+      this.add
+        .text(w / 2, h * 0.11, "Select your starter mech to begin", {
+          fontSize: `${Math.max(12, Math.floor(w * 0.018))}px`,
+          color: "#888888",
+        })
+        .setOrigin(0.5),
+    );
+
+    let bindingIndex = 0;
+    const cardW = Math.min(w * 0.85, 400);
+    const cardH = Math.max(60, h * 0.12);
+    const cardX = (w - cardW) / 2;
+    const startY = h * 0.17;
+    const gap = 8;
+    const fontSize = `${Math.max(12, Math.floor(w * 0.018))}px`;
+    const subFont = `${Math.max(10, Math.floor(w * 0.014))}px`;
+
+    const drawCards = () => {
+      // Remove old card elements (tagged)
+      for (const obj of overlay.list.filter((o) =>
+        (o as Phaser.GameObjects.GameObject).getData("card"),
+      )) {
+        obj.destroy();
+      }
+
+      for (let i = 0; i < MECH_ROSTER.length; i++) {
+        const mech = MECH_ROSTER[i];
+        const y = startY + i * (cardH + gap);
+        const isSelected = i === bindingIndex;
+
+        const cardBg = this.add.graphics();
+        cardBg.setData("card", true);
+        cardBg.fillStyle(isSelected ? 0x1a3a1a : COLORS.panelBg, 1);
+        cardBg.fillRoundedRect(cardX, y, cardW, cardH, 8);
+        cardBg.lineStyle(2, isSelected ? COLORS.accentHex : COLORS.panelBorder);
+        cardBg.strokeRoundedRect(cardX, y, cardW, cardH, 8);
+        overlay.add(cardBg);
+
+        const typeColor = TYPE_COLORS[mech.type] ?? COLORS.text;
+
+        // Portrait
+        const portraitSize = Math.min(48, cardH - 12);
+        const portrait = ASSET_REGISTRY.portraits[mech.type];
+        if (portrait) {
+          const key = portrait.normal.key;
+          if (this.textures.exists(key)) {
+            const img = this.add
+              .image(cardX + 10 + portraitSize / 2, y + cardH / 2, key)
+              .setDisplaySize(portraitSize, portraitSize)
+              .setData("card", true);
+            overlay.add(img);
+          }
+        }
+
+        const textX = cardX + 10 + portraitSize + 12;
+
+        const name = this.add
+          .text(textX, y + 8, mech.codename ?? mech.name, {
+            fontSize,
+            color: typeColor,
+            fontStyle: "bold",
+          })
+          .setData("card", true);
+        overlay.add(name);
+
+        const role = this.add
+          .text(textX, y + 26, `${mech.role ?? mech.type.toUpperCase()}`, {
+            fontSize: subFont,
+            color: "#888888",
+          })
+          .setData("card", true);
+        overlay.add(role);
+
+        if (mech.bio) {
+          const bio = this.add
+            .text(textX, y + 40, mech.bio, {
+              fontSize: `${Math.max(9, Math.floor(w * 0.012))}px`,
+              color: "#666666",
+              wordWrap: { width: cardW - portraitSize - 40 },
+            })
+            .setData("card", true);
+          overlay.add(bio);
+        }
+
+        const zone = this.add
+          .zone(cardX, y, cardW, cardH)
+          .setOrigin(0)
+          .setInteractive({ useHandCursor: true })
+          .setData("card", true);
+
+        zone.on("pointerdown", () => {
+          bindingIndex = i;
+          drawCards();
+        });
+        overlay.add(zone);
+      }
+    };
+
+    drawCards();
+
+    // Confirm button
+    const btnW = Math.min(w * 0.5, 220);
+    const btnH = 44;
+    const btnX = w / 2 - btnW / 2;
+    const btnY = h * 0.17 + MECH_ROSTER.length * (cardH + gap) + 16;
+
+    const confirmBg = this.add.graphics();
+    confirmBg.fillStyle(COLORS.accentHex, 1);
+    confirmBg.fillRoundedRect(btnX, btnY, btnW, btnH, 8);
+    overlay.add(confirmBg);
+
+    overlay.add(
+      this.add
+        .text(w / 2, btnY + btnH / 2, "Choose This Mech", {
+          fontSize: `${Math.max(15, Math.floor(w * 0.023))}px`,
+          color: "#000000",
+          fontStyle: "bold",
+        })
+        .setOrigin(0.5),
+    );
+
+    const confirmZone = this.add
+      .zone(btnX, btnY, btnW, btnH)
+      .setOrigin(0)
+      .setInteractive({ useHandCursor: true });
+
+    confirmZone.on("pointerover", () => {
+      confirmBg.clear();
+      confirmBg.fillStyle(0x00cc66, 1);
+      confirmBg.fillRoundedRect(btnX, btnY, btnW, btnH, 8);
+    });
+    confirmZone.on("pointerout", () => {
+      confirmBg.clear();
+      confirmBg.fillStyle(COLORS.accentHex, 1);
+      confirmBg.fillRoundedRect(btnX, btnY, btnW, btnH, 8);
+    });
+    confirmZone.on("pointerdown", () => {
+      saveStarterMech(bindingIndex);
+      this.selectedIndex = bindingIndex;
+      overlay.destroy();
+      this.buildUI(w, h);
+
+      if (!hasSeenOnboarding()) {
+        this.showOnboarding();
+      }
+    });
+    overlay.add(confirmZone);
   }
 
   // --- Onboarding ---

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -212,3 +212,22 @@ export function hasSeenOnboarding(): boolean {
 export function markOnboardingSeen(): void {
   localStorage.setItem(ONBOARDING_KEY, "true");
 }
+
+// --- Starter Mech ---
+
+const STARTER_MECH_KEY = "mechArena_starterMech";
+
+export function hasStarterMech(): boolean {
+  return localStorage.getItem(STARTER_MECH_KEY) !== null;
+}
+
+export function loadStarterMech(): number {
+  const val = localStorage.getItem(STARTER_MECH_KEY);
+  if (val === null) return 0;
+  const idx = Number.parseInt(val, 10);
+  return Number.isNaN(idx) ? 0 : idx;
+}
+
+export function saveStarterMech(index: number): void {
+  localStorage.setItem(STARTER_MECH_KEY, String(index));
+}

--- a/tests/mechBinding.test.ts
+++ b/tests/mechBinding.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+// Mock localStorage
+class MockStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+const mockStorage = new MockStorage();
+(globalThis as Record<string, unknown>).localStorage = mockStorage;
+
+const { hasStarterMech, loadStarterMech, saveStarterMech } = await import(
+  "../src/utils/storage"
+);
+
+describe("starter mech persistence", () => {
+  afterEach(() => {
+    mockStorage.clear();
+  });
+
+  it("should return false when no starter is saved", () => {
+    assert.equal(hasStarterMech(), false);
+  });
+
+  it("should return true after saving a starter", () => {
+    saveStarterMech(1);
+    assert.equal(hasStarterMech(), true);
+  });
+
+  it("should load saved starter index", () => {
+    saveStarterMech(2);
+    assert.equal(loadStarterMech(), 2);
+  });
+
+  it("should default to 0 when no starter saved", () => {
+    assert.equal(loadStarterMech(), 0);
+  });
+
+  it("should persist index 0", () => {
+    saveStarterMech(0);
+    assert.equal(hasStarterMech(), true);
+    assert.equal(loadStarterMech(), 0);
+  });
+
+  it("should overwrite previous selection", () => {
+    saveStarterMech(0);
+    saveStarterMech(2);
+    assert.equal(loadStarterMech(), 2);
+  });
+
+  it("should handle corrupted value gracefully", () => {
+    mockStorage.setItem("mechArena_starterMech", "invalid");
+    assert.equal(loadStarterMech(), 0);
+  });
+
+  it("should reset when localStorage is cleared", () => {
+    saveStarterMech(1);
+    mockStorage.clear();
+    assert.equal(hasStarterMech(), false);
+    assert.equal(loadStarterMech(), 0);
+  });
+});
+
+describe("mech binding flow logic", () => {
+  afterEach(() => {
+    mockStorage.clear();
+  });
+
+  it("should show binding when no starter exists", () => {
+    const shouldShowBinding = !hasStarterMech();
+    assert.equal(shouldShowBinding, true);
+  });
+
+  it("should skip binding when starter exists", () => {
+    saveStarterMech(1);
+    const shouldShowBinding = !hasStarterMech();
+    assert.equal(shouldShowBinding, false);
+  });
+
+  it("should show onboarding after binding if not seen", async () => {
+    saveStarterMech(0);
+    const { hasSeenOnboarding } = await import("../src/utils/storage");
+    const shouldShowOnboarding = hasStarterMech() && !hasSeenOnboarding();
+    assert.equal(shouldShowOnboarding, true);
+  });
+});


### PR DESCRIPTION
## Summary
- Added `hasStarterMech()`/`loadStarterMech()`/`saveStarterMech()` to storage
- Full-screen mech binding overlay on first run: 3 mech cards with portrait, codename, role, bio
- Click to select, "Choose This Mech" to confirm and persist
- Saved starter loaded on subsequent visits
- Binding shows before onboarding (correct sequence)
- 11 new tests covering persistence, corrupted values, and flow logic

## Test plan
- [x] 420/421 tests pass (1 pre-existing failure in assetRegistry.test.ts)
- [x] 11 new mech binding tests pass
- [ ] Visual verification: binding overlay on first visit, saved mech persists

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)