### PR TITLE
feat: add initial strategy template selection during setup

### DIFF
--- a/src/data/strategies.ts
+++ b/src/data/strategies.ts
@@ -1,0 +1,28 @@
+/** Starter strategy templates for new player initialization. */
+
+export interface StrategyTemplate {
+  name: string;
+  icon: string;
+  prompt: string;
+}
+
+export const STRATEGY_TEMPLATES: StrategyTemplate[] = [
+  {
+    name: "Aggressive",
+    icon: "\u2694\uFE0F",
+    prompt:
+      "Always prioritize the highest damage attack. Use super-effective moves when possible. Only use defense as a last resort when HP is critically low.",
+  },
+  {
+    name: "Balanced",
+    icon: "\u2696\uFE0F",
+    prompt:
+      "Use a mix of offense and defense. Attack with type advantage when available. Switch to defense when HP drops below 40%. Prioritize consistent damage over risky plays.",
+  },
+  {
+    name: "Defensive",
+    icon: "\uD83D\uDEE1\uFE0F",
+    prompt:
+      "Prioritize survival. Use Iron Defense frequently to build up shields. Only attack when HP is above 60%. Prefer resisted attacks over risky super-effective moves.",
+  },
+];

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -5,12 +5,14 @@
 import Phaser from "phaser";
 import { ASSET_REGISTRY, preloadAllAssets } from "../assets";
 import { MECH_ROSTER, OPPONENT_MECH } from "../data/mechs";
+import { STRATEGY_TEMPLATES } from "../data/strategies";
 import {
   hasSeenOnboarding,
   hasStarterMech,
   loadMechPrompt,
   loadStarterMech,
   markOnboardingSeen,
+  saveMechPrompt,
   saveStarterMech,
 } from "../utils/storage";
 
@@ -601,6 +603,153 @@ export class LobbyScene extends Phaser.Scene {
       this.selectedIndex = bindingIndex;
       overlay.destroy();
       this.buildUI(w, h);
+      this.showStrategyPicker();
+    });
+    overlay.add(confirmZone);
+  }
+
+  // --- Strategy Picker ---
+
+  private showStrategyPicker(): void {
+    const { width: w, height: h } = this.scale;
+    const overlay = this.add.container(0, 0);
+
+    // Backdrop
+    const bg = this.add.graphics();
+    bg.fillStyle(0x000000, 0.9);
+    bg.fillRect(0, 0, w, h);
+    overlay.add(bg);
+
+    // Title
+    overlay.add(
+      this.add
+        .text(w / 2, h * 0.06, "CHOOSE YOUR STRATEGY", {
+          fontSize: `${Math.max(20, Math.floor(w * 0.035))}px`,
+          color: COLORS.accent,
+          fontStyle: "bold",
+        })
+        .setOrigin(0.5),
+    );
+
+    overlay.add(
+      this.add
+        .text(w / 2, h * 0.11, "Pick a battle style to start with", {
+          fontSize: `${Math.max(12, Math.floor(w * 0.018))}px`,
+          color: "#888888",
+        })
+        .setOrigin(0.5),
+    );
+
+    let pickerIndex = 0;
+    const cardW = Math.min(w * 0.85, 400);
+    const cardH = Math.max(70, h * 0.14);
+    const cardX = (w - cardW) / 2;
+    const startY = h * 0.17;
+    const gap = 10;
+    const fontSize = `${Math.max(13, Math.floor(w * 0.02))}px`;
+    const subFont = `${Math.max(10, Math.floor(w * 0.014))}px`;
+
+    const drawCards = () => {
+      for (const obj of overlay.list.filter((o) =>
+        (o as Phaser.GameObjects.GameObject).getData("scard"),
+      )) {
+        obj.destroy();
+      }
+
+      for (let i = 0; i < STRATEGY_TEMPLATES.length; i++) {
+        const tmpl = STRATEGY_TEMPLATES[i];
+        const y = startY + i * (cardH + gap);
+        const isSelected = i === pickerIndex;
+
+        const cardBg = this.add.graphics();
+        cardBg.setData("scard", true);
+        cardBg.fillStyle(isSelected ? 0x1a2a3a : COLORS.panelBg, 1);
+        cardBg.fillRoundedRect(cardX, y, cardW, cardH, 8);
+        cardBg.lineStyle(2, isSelected ? COLORS.accentHex : COLORS.panelBorder);
+        cardBg.strokeRoundedRect(cardX, y, cardW, cardH, 8);
+        overlay.add(cardBg);
+
+        // Icon + Name
+        overlay.add(
+          this.add
+            .text(cardX + 15, y + 10, `${tmpl.icon}  ${tmpl.name}`, {
+              fontSize,
+              color: isSelected ? COLORS.accent : COLORS.text,
+              fontStyle: "bold",
+            })
+            .setData("scard", true),
+        );
+
+        // Prompt preview
+        const preview =
+          tmpl.prompt.length > 80
+            ? `${tmpl.prompt.slice(0, 77)}...`
+            : tmpl.prompt;
+        overlay.add(
+          this.add
+            .text(cardX + 15, y + 32, preview, {
+              fontSize: subFont,
+              color: "#888888",
+              wordWrap: { width: cardW - 30 },
+            })
+            .setData("scard", true),
+        );
+
+        const zone = this.add
+          .zone(cardX, y, cardW, cardH)
+          .setOrigin(0)
+          .setInteractive({ useHandCursor: true })
+          .setData("scard", true);
+
+        zone.on("pointerdown", () => {
+          pickerIndex = i;
+          drawCards();
+        });
+        overlay.add(zone);
+      }
+    };
+
+    drawCards();
+
+    // Confirm button
+    const btnW = Math.min(w * 0.5, 220);
+    const btnH = 44;
+    const btnX = w / 2 - btnW / 2;
+    const btnY = startY + STRATEGY_TEMPLATES.length * (cardH + gap) + 12;
+
+    const confirmBg = this.add.graphics();
+    confirmBg.fillStyle(COLORS.accentHex, 1);
+    confirmBg.fillRoundedRect(btnX, btnY, btnW, btnH, 8);
+    overlay.add(confirmBg);
+
+    overlay.add(
+      this.add
+        .text(w / 2, btnY + btnH / 2, "Use This Strategy", {
+          fontSize: `${Math.max(15, Math.floor(w * 0.023))}px`,
+          color: "#000000",
+          fontStyle: "bold",
+        })
+        .setOrigin(0.5),
+    );
+
+    const confirmZone = this.add
+      .zone(btnX, btnY, btnW, btnH)
+      .setOrigin(0)
+      .setInteractive({ useHandCursor: true });
+
+    confirmZone.on("pointerover", () => {
+      confirmBg.clear();
+      confirmBg.fillStyle(0x00cc66, 1);
+      confirmBg.fillRoundedRect(btnX, btnY, btnW, btnH, 8);
+    });
+    confirmZone.on("pointerout", () => {
+      confirmBg.clear();
+      confirmBg.fillStyle(COLORS.accentHex, 1);
+      confirmBg.fillRoundedRect(btnX, btnY, btnW, btnH, 8);
+    });
+    confirmZone.on("pointerdown", () => {
+      saveMechPrompt(STRATEGY_TEMPLATES[pickerIndex].prompt);
+      overlay.destroy();
 
       if (!hasSeenOnboarding()) {
         this.showOnboarding();

--- a/tests/strategyTemplates.test.ts
+++ b/tests/strategyTemplates.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { STRATEGY_TEMPLATES } from "../src/data/strategies";
+
+describe("STRATEGY_TEMPLATES", () => {
+  it("should contain at least 3 templates", () => {
+    assert.ok(STRATEGY_TEMPLATES.length >= 3);
+  });
+
+  it("each template should have name, icon, and prompt", () => {
+    for (const tmpl of STRATEGY_TEMPLATES) {
+      assert.ok(tmpl.name.length > 0, "name should not be empty");
+      assert.ok(tmpl.icon.length > 0, "icon should not be empty");
+      assert.ok(tmpl.prompt.length > 0, "prompt should not be empty");
+    }
+  });
+
+  it("should include Aggressive template", () => {
+    assert.ok(STRATEGY_TEMPLATES.some((t) => t.name === "Aggressive"));
+  });
+
+  it("should include Balanced template", () => {
+    assert.ok(STRATEGY_TEMPLATES.some((t) => t.name === "Balanced"));
+  });
+
+  it("should include Defensive template", () => {
+    assert.ok(STRATEGY_TEMPLATES.some((t) => t.name === "Defensive"));
+  });
+
+  it("template names should be unique", () => {
+    const names = STRATEGY_TEMPLATES.map((t) => t.name);
+    assert.equal(new Set(names).size, names.length);
+  });
+
+  it("prompts should be non-trivial (> 30 chars)", () => {
+    for (const tmpl of STRATEGY_TEMPLATES) {
+      assert.ok(tmpl.prompt.length > 30, `${tmpl.name} prompt too short`);
+    }
+  });
+
+  it("prompts should be within 500 char limit", () => {
+    for (const tmpl of STRATEGY_TEMPLATES) {
+      assert.ok(
+        tmpl.prompt.length <= 500,
+        `${tmpl.name} prompt exceeds 500 chars`,
+      );
+    }
+  });
+});
+
+describe("strategy template content", () => {
+  it("Aggressive should mention high damage", () => {
+    const tmpl = STRATEGY_TEMPLATES.find((t) => t.name === "Aggressive");
+    assert.ok(tmpl);
+    assert.ok(
+      tmpl.prompt.toLowerCase().includes("damage") ||
+        tmpl.prompt.toLowerCase().includes("attack"),
+    );
+  });
+
+  it("Balanced should mention both offense and defense", () => {
+    const tmpl = STRATEGY_TEMPLATES.find((t) => t.name === "Balanced");
+    assert.ok(tmpl);
+    assert.ok(tmpl.prompt.toLowerCase().includes("defense"));
+    assert.ok(
+      tmpl.prompt.toLowerCase().includes("attack") ||
+        tmpl.prompt.toLowerCase().includes("offense"),
+    );
+  });
+
+  it("Defensive should mention survival or defense", () => {
+    const tmpl = STRATEGY_TEMPLATES.find((t) => t.name === "Defensive");
+    assert.ok(tmpl);
+    assert.ok(
+      tmpl.prompt.toLowerCase().includes("defense") ||
+        tmpl.prompt.toLowerCase().includes("survival") ||
+        tmpl.prompt.toLowerCase().includes("survive"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Created `src/data/strategies.ts` with 3 starter templates: Aggressive, Balanced, Defensive
- Added strategy picker overlay after mech binding in LobbyScene
- 3 strategy cards with icon, name, prompt preview; click to select, confirm to save
- Selected template saved as mechPrompt via saveMechPrompt()
- Flow: mech binding → strategy picker → onboarding (complete first-run initialization)
- 11 new tests covering template structure, content validation, uniqueness, prompt limits

## Test plan
- [x] 431/432 tests pass (1 pre-existing failure in assetRegistry.test.ts)
- [x] 11 new strategy template tests pass
- [ ] Visual verification: strategy picker overlay after mech selection

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)