### PR TITLE
feat: integrate initialization flow with reset capability

### DIFF
--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -7,6 +7,7 @@ import { ASSET_REGISTRY, preloadAllAssets } from "../assets";
 import { MECH_ROSTER, OPPONENT_MECH } from "../data/mechs";
 import { STRATEGY_TEMPLATES } from "../data/strategies";
 import {
+  clearStarterMech,
   hasSeenOnboarding,
   hasStarterMech,
   loadMechPrompt,
@@ -435,6 +436,34 @@ export class LobbyScene extends Phaser.Scene {
 
     helpZone.on("pointerdown", () => {
       this.showOnboarding();
+    });
+
+    // Reset button
+    const resetX = helpX - helpSize - 8;
+    const resetText = this.add
+      .text(resetX + helpSize / 2, helpY + helpSize / 2, "\u21BA", {
+        fontSize: `${Math.max(14, Math.floor(w * 0.02))}px`,
+        color: "#666666",
+      })
+      .setOrigin(0.5);
+
+    const resetBg = this.add.graphics();
+    resetBg.fillStyle(COLORS.buttonBg, 1);
+    resetBg.fillRoundedRect(resetX, helpY, helpSize, helpSize, 6);
+    resetBg.lineStyle(1, COLORS.panelBorder);
+    resetBg.strokeRoundedRect(resetX, helpY, helpSize, helpSize, 6);
+
+    // Ensure text is above background
+    resetText.setDepth(1);
+
+    const resetZone = this.add
+      .zone(resetX, helpY, helpSize, helpSize)
+      .setOrigin(0)
+      .setInteractive({ useHandCursor: true });
+
+    resetZone.on("pointerdown", () => {
+      clearStarterMech();
+      this.scene.restart();
     });
   }
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -231,3 +231,8 @@ export function loadStarterMech(): number {
 export function saveStarterMech(index: number): void {
   localStorage.setItem(STARTER_MECH_KEY, String(index));
 }
+
+export function clearStarterMech(): void {
+  localStorage.removeItem(STARTER_MECH_KEY);
+  localStorage.removeItem(ONBOARDING_KEY);
+}

--- a/tests/initIntegration.test.ts
+++ b/tests/initIntegration.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+// Mock localStorage
+class MockStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+const mockStorage = new MockStorage();
+(globalThis as Record<string, unknown>).localStorage = mockStorage;
+
+const {
+  clearStarterMech,
+  hasSeenOnboarding,
+  hasStarterMech,
+  loadStarterMech,
+  markOnboardingSeen,
+  saveStarterMech,
+} = await import("../src/utils/storage");
+
+describe("clearStarterMech", () => {
+  afterEach(() => {
+    mockStorage.clear();
+  });
+
+  it("should clear starter mech", () => {
+    saveStarterMech(2);
+    assert.equal(hasStarterMech(), true);
+    clearStarterMech();
+    assert.equal(hasStarterMech(), false);
+  });
+
+  it("should clear onboarding state", () => {
+    markOnboardingSeen();
+    assert.equal(hasSeenOnboarding(), true);
+    clearStarterMech();
+    assert.equal(hasSeenOnboarding(), false);
+  });
+
+  it("should clear both starter and onboarding together", () => {
+    saveStarterMech(1);
+    markOnboardingSeen();
+    clearStarterMech();
+    assert.equal(hasStarterMech(), false);
+    assert.equal(hasSeenOnboarding(), false);
+  });
+
+  it("should default starter to 0 after clear", () => {
+    saveStarterMech(2);
+    clearStarterMech();
+    assert.equal(loadStarterMech(), 0);
+  });
+
+  it("should be safe to call when nothing is saved", () => {
+    assert.doesNotThrow(() => clearStarterMech());
+  });
+});
+
+describe("initialization flow integration", () => {
+  afterEach(() => {
+    mockStorage.clear();
+  });
+
+  it("fresh state should trigger mech binding", () => {
+    assert.equal(!hasStarterMech(), true);
+  });
+
+  it("after binding, should trigger onboarding if not seen", () => {
+    saveStarterMech(0);
+    assert.equal(hasStarterMech(), true);
+    assert.equal(!hasSeenOnboarding(), true);
+  });
+
+  it("after binding + onboarding, should go to normal lobby", () => {
+    saveStarterMech(1);
+    markOnboardingSeen();
+    assert.equal(hasStarterMech(), true);
+    assert.equal(hasSeenOnboarding(), true);
+  });
+
+  it("reset should restore fresh state", () => {
+    saveStarterMech(1);
+    markOnboardingSeen();
+    clearStarterMech();
+    // Should be back to fresh state
+    assert.equal(hasStarterMech(), false);
+    assert.equal(hasSeenOnboarding(), false);
+  });
+
+  it("full lifecycle: fresh → bind → onboard → normal → reset → fresh", () => {
+    // Fresh
+    assert.equal(hasStarterMech(), false);
+
+    // Bind
+    saveStarterMech(2);
+    assert.equal(hasStarterMech(), true);
+    assert.equal(loadStarterMech(), 2);
+
+    // Onboard
+    markOnboardingSeen();
+    assert.equal(hasSeenOnboarding(), true);
+
+    // Normal lobby (all set)
+    assert.equal(hasStarterMech(), true);
+    assert.equal(hasSeenOnboarding(), true);
+
+    // Reset
+    clearStarterMech();
+    assert.equal(hasStarterMech(), false);
+    assert.equal(hasSeenOnboarding(), false);
+  });
+});


### PR DESCRIPTION
## Summary
- Added `clearStarterMech()` to storage (clears both starter mech and onboarding state)
- Added reset button (↺) in lobby next to help (?) button
- Reset triggers full re-initialization: mech binding → strategy picker → onboarding
- 10 new tests covering clear behavior and full initialization lifecycle

## Test plan
- [x] 441/442 tests pass (1 pre-existing failure in assetRegistry.test.ts)
- [x] 10 new init integration tests pass
- [ ] Visual verification: reset button triggers full setup flow

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)