### PR TITLE
feat: fix AI prompt skill names to match actual game skills

### DIFF
--- a/api/battle.ts
+++ b/api/battle.ts
@@ -14,6 +14,7 @@ interface BattleRequest {
     opponentHP: number;
     lastMove: string;
     statusEffects: string[];
+    skills?: Array<{ name: string; type: string; damage: number }>;
   };
 }
 
@@ -99,6 +100,13 @@ export function mockBattleResponse(body: BattleRequest): BattleResponse {
 
 export function buildPrompt(body: BattleRequest): string {
   const { mechPrompt, gameState } = body;
+
+  const skillList = gameState.skills
+    ? gameState.skills
+        .map((s, i) => `${i}: ${s.name} (${s.type}, ${s.damage} dmg)`)
+        .join("\n")
+    : "Skills not available";
+
   return `You are an AI controlling a battle mech. The player has given you this strategy:
 "${mechPrompt}"
 
@@ -109,10 +117,7 @@ Current game state:
 - Active status effects: ${gameState.statusEffects.length > 0 ? gameState.statusEffects.join(", ") : "none"}
 
 Available skills (choose by index):
-0: Laser Beam - High damage, low accuracy
-1: Shield Bash - Medium damage, raises defense
-2: Repair - Heals HP, skips attack
-3: EMP Strike - Disables opponent's next move
+${skillList}
 
 Based on the strategy and game state, choose the best skill index (0-3).
 Respond with EXACTLY this format:

--- a/src/api/battleClient.ts
+++ b/src/api/battleClient.ts
@@ -9,6 +9,7 @@ interface BattleAPIRequest {
     opponentHP: number;
     lastMove: string;
     statusEffects: string[];
+    skills: Array<{ name: string; type: string; damage: number }>;
   };
 }
 
@@ -31,6 +32,11 @@ function buildRequestBody(
       opponentHP: state.opponent.hp,
       lastMove: lastLog,
       statusEffects: [],
+      skills: state.player.skills.map((s) => ({
+        name: s.name,
+        type: String(s.type),
+        damage: s.damage,
+      })),
     },
   };
 }

--- a/tests/battle-api.test.ts
+++ b/tests/battle-api.test.ts
@@ -8,6 +8,13 @@ import {
   rateLimitMap,
 } from "../api/battle.ts";
 
+const TEST_SKILLS = [
+  { name: "Railgun Salvo", type: "kinetic", damage: 40 },
+  { name: "Plasma Beam", type: "beam", damage: 30 },
+  { name: "EMP Pulse", type: "emp", damage: 25 },
+  { name: "Reactive Armor", type: "defense", damage: 0 },
+];
+
 describe("buildPrompt", () => {
   it("should contain game state and player strategy", () => {
     const prompt = buildPrompt({
@@ -15,16 +22,47 @@ describe("buildPrompt", () => {
       gameState: {
         playerHP: 80,
         opponentHP: 60,
-        lastMove: "Shield Bash",
+        lastMove: "Railgun Salvo",
         statusEffects: ["defense_up"],
+        skills: TEST_SKILLS,
       },
     });
 
     assert.ok(prompt.includes("Be aggressive"));
     assert.ok(prompt.includes("80"));
     assert.ok(prompt.includes("60"));
-    assert.ok(prompt.includes("Shield Bash"));
+    assert.ok(prompt.includes("Railgun Salvo"));
     assert.ok(prompt.includes("defense_up"));
+  });
+
+  it("should include actual skill names from skills array", () => {
+    const prompt = buildPrompt({
+      mechPrompt: "test",
+      gameState: {
+        playerHP: 100,
+        opponentHP: 100,
+        lastMove: "",
+        statusEffects: [],
+        skills: TEST_SKILLS,
+      },
+    });
+
+    assert.ok(prompt.includes("Railgun Salvo"), "should contain Railgun Salvo");
+    assert.ok(prompt.includes("Plasma Beam"), "should contain Plasma Beam");
+    assert.ok(prompt.includes("EMP Pulse"), "should contain EMP Pulse");
+    assert.ok(
+      prompt.includes("Reactive Armor"),
+      "should contain Reactive Armor",
+    );
+    assert.ok(prompt.includes("kinetic"), "should contain kinetic type");
+    assert.ok(prompt.includes("40 dmg"), "should contain damage value");
+    // Should NOT contain old hardcoded names
+    assert.ok(!prompt.includes("Laser Beam"), "should not contain Laser Beam");
+    assert.ok(
+      !prompt.includes("Shield Bash"),
+      "should not contain Shield Bash",
+    );
+    assert.ok(!prompt.includes("Repair"), "should not contain Repair");
   });
 
   it("should handle empty status effects", () => {
@@ -35,11 +73,26 @@ describe("buildPrompt", () => {
         opponentHP: 100,
         lastMove: "",
         statusEffects: [],
+        skills: TEST_SKILLS,
       },
     });
 
     assert.ok(prompt.includes("Play safe"));
     assert.ok(prompt.includes("none"));
+  });
+
+  it("should fallback when skills not provided", () => {
+    const prompt = buildPrompt({
+      mechPrompt: "test",
+      gameState: {
+        playerHP: 100,
+        opponentHP: 100,
+        lastMove: "",
+        statusEffects: [],
+      },
+    });
+
+    assert.ok(prompt.includes("Skills not available"));
   });
 });
 

--- a/tests/battleClient.test.ts
+++ b/tests/battleClient.test.ts
@@ -82,6 +82,9 @@ describe("callBattleAPI", () => {
     assert.equal(body.gameState.playerHP, 80);
     assert.equal(body.gameState.opponentHP, 60);
     assert.equal(body.gameState.lastMove, "[EFF]PlayerMech used Fire Blast!");
+    assert.ok(Array.isArray(body.gameState.skills), "should include skills");
+    assert.equal(body.gameState.skills.length, 4);
+    assert.equal(body.gameState.skills[0].name, "Railgun Salvo");
   });
 
   it("should return null after max retries on network error", async () => {


### PR DESCRIPTION
## Summary
- Client (`battleClient.ts`) now sends player's actual skills array in `gameState.skills`
- API (`battle.ts`) `buildPrompt()` generates skill list dynamically from skills data
  (e.g. `0: Railgun Salvo (kinetic, 40 dmg)`) instead of hardcoded wrong names
- Falls back to "Skills not available" when `skills` field is absent (backward compat)
- Old hardcoded names (Laser Beam, Shield Bash, Repair, EMP Strike) completely removed

## Test plan
- [x] 486/486 tests pass (all green)
- [x] `buildPrompt` tests verify dynamic skill names appear and old names don't
- [x] `callBattleAPI` test verifies skills array is sent in request body
- [x] Fallback test verifies graceful handling without skills field

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)