### PR TITLE
feat: optimize bundle size with lazy loading

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,6 @@
  */
 
 import { BattleScene } from "@/scenes/BattleScene";
-import { HistoryScene } from "@/scenes/HistoryScene";
 import { LobbyScene } from "@/scenes/LobbyScene";
 import { registerSW } from "@/utils/pwa";
 import Phaser from "phaser";
@@ -19,7 +18,7 @@ const config: Phaser.Types.Core.GameConfig = {
     min: { width: 320, height: 240 },
     max: { width: 1920, height: 1080 },
   },
-  scene: [LobbyScene, BattleScene, HistoryScene],
+  scene: [LobbyScene, BattleScene],
 };
 
 new Phaser.Game(config);

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -6,6 +6,7 @@ import Phaser from "phaser";
 import { ASSET_REGISTRY, preloadAllAssets } from "../assets";
 import { MECH_ROSTER, OPPONENT_MECH } from "../data/mechs";
 import { STRATEGY_TEMPLATES } from "../data/strategies";
+import { launchHistoryScene } from "../utils/lazyScene";
 import {
   clearStarterMech,
   hasSeenOnboarding,
@@ -407,7 +408,7 @@ export class LobbyScene extends Phaser.Scene {
     });
     histZone.on("pointerdown", () => {
       this.scale.off("resize", this.handleResize, this);
-      this.scene.start("HistoryScene");
+      launchHistoryScene(this);
     });
 
     // Help button

--- a/src/scenes/battle/BattleResult.ts
+++ b/src/scenes/battle/BattleResult.ts
@@ -7,6 +7,7 @@ import { OPPONENT_MECH } from "../../data/mechs";
 import type { Mech } from "../../types/game";
 import type { BattleRecord } from "../../types/storage";
 import type { BattleManager } from "../../utils/BattleManager";
+import { launchHistoryScene } from "../../utils/lazyScene";
 import { saveBattleHistory } from "../../utils/storage";
 import {
   isMuted,
@@ -78,7 +79,7 @@ export function createHistoryButton(
 
   zone.on("pointerdown", () => {
     onCleanup();
-    scene.scene.start("HistoryScene");
+    launchHistoryScene(scene);
   });
 }
 
@@ -310,7 +311,7 @@ export function showResultScreen(
   });
 
   histZone.on("pointerdown", () => {
-    scene.scene.start("HistoryScene");
+    launchHistoryScene(scene);
   });
   resultOverlay.add(histZone);
 

--- a/src/utils/lazyScene.ts
+++ b/src/utils/lazyScene.ts
@@ -1,0 +1,17 @@
+/**
+ * Lazy scene loader — dynamically imports and registers Phaser scenes on demand.
+ */
+
+/**
+ * Launch HistoryScene on demand. Dynamically imports and registers
+ * the scene if not already present, then starts it.
+ */
+export async function launchHistoryScene(
+  currentScene: Phaser.Scene,
+): Promise<void> {
+  if (!currentScene.scene.get("HistoryScene")) {
+    const { HistoryScene } = await import("../scenes/HistoryScene");
+    currentScene.scene.add("HistoryScene", HistoryScene, false);
+  }
+  currentScene.scene.start("HistoryScene");
+}

--- a/tests/lazyScene.test.ts
+++ b/tests/lazyScene.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+describe("lazy scene loading", () => {
+  it("HistoryScene should NOT be in main.ts scene array", async () => {
+    // Read main.ts to verify HistoryScene is not statically registered
+    const { readFile } = await import("node:fs/promises");
+    const { resolve } = await import("node:path");
+    const mainTs = await readFile(
+      resolve(import.meta.dirname, "..", "src", "main.ts"),
+      "utf-8",
+    );
+
+    assert.ok(
+      !mainTs.includes("import { HistoryScene }"),
+      "main.ts should not statically import HistoryScene",
+    );
+    assert.ok(
+      !mainTs.includes("HistoryScene"),
+      "main.ts should not reference HistoryScene at all",
+    );
+  });
+
+  it("lazyScene.ts should exist and export launchHistoryScene", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const { resolve } = await import("node:path");
+    const lazyTs = await readFile(
+      resolve(import.meta.dirname, "..", "src", "utils", "lazyScene.ts"),
+      "utf-8",
+    );
+
+    assert.ok(
+      lazyTs.includes("export async function launchHistoryScene"),
+      "should export launchHistoryScene",
+    );
+    assert.ok(lazyTs.includes("await import("), "should use dynamic import");
+    assert.ok(
+      lazyTs.includes("scene.add"),
+      "should register scene dynamically with scene.add",
+    );
+  });
+
+  it("BattleResult should use launchHistoryScene instead of scene.start", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const { resolve } = await import("node:path");
+    const resultTs = await readFile(
+      resolve(
+        import.meta.dirname,
+        "..",
+        "src",
+        "scenes",
+        "battle",
+        "BattleResult.ts",
+      ),
+      "utf-8",
+    );
+
+    assert.ok(
+      !resultTs.includes('scene.start("HistoryScene")'),
+      "should not have direct scene.start for HistoryScene",
+    );
+    assert.ok(
+      resultTs.includes("launchHistoryScene"),
+      "should use launchHistoryScene",
+    );
+  });
+
+  it("LobbyScene should use launchHistoryScene instead of scene.start", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const { resolve } = await import("node:path");
+    const lobbyTs = await readFile(
+      resolve(import.meta.dirname, "..", "src", "scenes", "LobbyScene.ts"),
+      "utf-8",
+    );
+
+    assert.ok(
+      !lobbyTs.includes('.start("HistoryScene")'),
+      "should not have direct scene.start for HistoryScene",
+    );
+    assert.ok(
+      lobbyTs.includes("launchHistoryScene"),
+      "should use launchHistoryScene",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Created `lazyScene.ts` helper that dynamically imports HistoryScene on demand
- Removed HistoryScene from main.ts static scene registration
- Replaced 3 `scene.start("HistoryScene")` calls with `launchHistoryScene()`
- Build produces separate chunk: `HistoryScene-*.js` (10.6KB / 3KB gzip)

### Build Output
| Chunk | Size | Gzip |
|-------|------|------|
| index (main) | 1,547 KB | 356 KB |
| HistoryScene (lazy) | 10.6 KB | 3 KB |

## Test plan
- [x] 490/490 tests pass (all green)
- [x] 4 new lazy loading tests verify wiring
- [x] Build produces separate HistoryScene chunk
- [ ] Visual verification: History loads without visible delay

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)