### PR TITLE
feat: add persistent player identity and starter mech setup

### DIFF
--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -11,9 +11,11 @@ import {
   clearStarterMech,
   hasSeenOnboarding,
   hasStarterMech,
+  loadCommanderName,
   loadMechPrompt,
   loadStarterMech,
   markOnboardingSeen,
+  saveCommanderName,
   saveMechPrompt,
   saveStarterMech,
 } from "../utils/storage";
@@ -77,10 +79,18 @@ export class LobbyScene extends Phaser.Scene {
 
     // Title
     this.add
-      .text(w / 2, h * 0.06, "MECH ARENA AI", {
+      .text(w / 2, h * 0.05, "MECH ARENA AI", {
         fontSize: `${Math.max(24, Math.floor(w * 0.04))}px`,
         color: COLORS.accent,
         fontStyle: "bold",
+      })
+      .setOrigin(0.5);
+
+    // Commander name
+    this.add
+      .text(w / 2, h * 0.1, `Commander: ${loadCommanderName()}`, {
+        fontSize: `${Math.max(11, Math.floor(w * 0.016))}px`,
+        color: "#888888",
       })
       .setOrigin(0.5);
 
@@ -483,7 +493,7 @@ export class LobbyScene extends Phaser.Scene {
     // Title
     overlay.add(
       this.add
-        .text(w / 2, h * 0.06, "CHOOSE YOUR MECH", {
+        .text(w / 2, h * 0.04, "SET UP YOUR IDENTITY", {
           fontSize: `${Math.max(20, Math.floor(w * 0.035))}px`,
           color: COLORS.accent,
           fontStyle: "bold",
@@ -491,9 +501,21 @@ export class LobbyScene extends Phaser.Scene {
         .setOrigin(0.5),
     );
 
+    // Commander name input (DOM overlay)
+    const nameInput = document.createElement("input");
+    nameInput.type = "text";
+    nameInput.maxLength = 20;
+    nameInput.placeholder = "Commander Name (optional)";
+    nameInput.style.cssText =
+      "position:fixed;top:12%;left:50%;transform:translateX(-50%);" +
+      "width:200px;max-width:80vw;padding:6px 10px;font-size:14px;" +
+      "font-family:monospace;background:#2a2a2a;color:#0f8;border:1px solid #444;" +
+      "border-radius:6px;outline:none;text-align:center;z-index:100;";
+    document.body.appendChild(nameInput);
+
     overlay.add(
       this.add
-        .text(w / 2, h * 0.11, "Select your starter mech to begin", {
+        .text(w / 2, h * 0.17, "Select your starter mech", {
           fontSize: `${Math.max(12, Math.floor(w * 0.018))}px`,
           color: "#888888",
         })
@@ -504,7 +526,7 @@ export class LobbyScene extends Phaser.Scene {
     const cardW = Math.min(w * 0.85, 400);
     const cardH = Math.max(60, h * 0.12);
     const cardX = (w - cardW) / 2;
-    const startY = h * 0.17;
+    const startY = h * 0.22;
     const gap = 8;
     const fontSize = `${Math.max(12, Math.floor(w * 0.018))}px`;
     const subFont = `${Math.max(10, Math.floor(w * 0.014))}px`;
@@ -596,7 +618,7 @@ export class LobbyScene extends Phaser.Scene {
     const btnW = Math.min(w * 0.5, 220);
     const btnH = 44;
     const btnX = w / 2 - btnW / 2;
-    const btnY = h * 0.17 + MECH_ROSTER.length * (cardH + gap) + 16;
+    const btnY = h * 0.22 + MECH_ROSTER.length * (cardH + gap) + 16;
 
     const confirmBg = this.add.graphics();
     confirmBg.fillStyle(COLORS.accentHex, 1);
@@ -629,6 +651,8 @@ export class LobbyScene extends Phaser.Scene {
       confirmBg.fillRoundedRect(btnX, btnY, btnW, btnH, 8);
     });
     confirmZone.on("pointerdown", () => {
+      saveCommanderName(nameInput.value);
+      nameInput.remove();
       saveStarterMech(bindingIndex);
       this.selectedIndex = bindingIndex;
       overlay.destroy();

--- a/src/scenes/battle/BattleUIPanel.ts
+++ b/src/scenes/battle/BattleUIPanel.ts
@@ -19,6 +19,7 @@ import {
   computeBackgroundLayout,
 } from "../../utils/backgroundConfig";
 import { LOG_MAX_LINES, parseLogMessage } from "../../utils/logColors";
+import { loadCommanderName } from "../../utils/storage";
 
 const COLORS = {
   text: "#ffffff",
@@ -354,7 +355,7 @@ export function createPlayerArea(
     .text(
       panelX + 10,
       panelY + 6,
-      `${playerMech.codename ?? playerMech.name}  Lv.5`,
+      `${loadCommanderName()} — ${playerMech.codename ?? playerMech.name}`,
       {
         fontSize: `${Math.max(11, Math.floor(w * 0.018))}px`,
         color: COLORS.text,

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -235,4 +235,24 @@ export function saveStarterMech(index: number): void {
 export function clearStarterMech(): void {
   localStorage.removeItem(STARTER_MECH_KEY);
   localStorage.removeItem(ONBOARDING_KEY);
+  localStorage.removeItem(COMMANDER_NAME_KEY);
+}
+
+// --- Commander Name ---
+
+const COMMANDER_NAME_KEY = "mechArena_commanderName";
+const DEFAULT_COMMANDER_NAME = "Commander";
+const MAX_COMMANDER_NAME_LENGTH = 20;
+
+export function loadCommanderName(): string {
+  return localStorage.getItem(COMMANDER_NAME_KEY) || DEFAULT_COMMANDER_NAME;
+}
+
+export function saveCommanderName(name: string): void {
+  const trimmed = name.trim().slice(0, MAX_COMMANDER_NAME_LENGTH);
+  localStorage.setItem(COMMANDER_NAME_KEY, trimmed || DEFAULT_COMMANDER_NAME);
+}
+
+export function hasCommanderName(): boolean {
+  return localStorage.getItem(COMMANDER_NAME_KEY) !== null;
 }

--- a/tests/commanderName.test.ts
+++ b/tests/commanderName.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+// Mock localStorage
+class MockStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+const mockStorage = new MockStorage();
+(globalThis as Record<string, unknown>).localStorage = mockStorage;
+
+const {
+  clearStarterMech,
+  hasCommanderName,
+  loadCommanderName,
+  saveCommanderName,
+  saveStarterMech,
+} = await import("../src/utils/storage");
+
+describe("commander name storage", () => {
+  afterEach(() => {
+    mockStorage.clear();
+  });
+
+  it("should return default 'Commander' when no name saved", () => {
+    assert.equal(loadCommanderName(), "Commander");
+  });
+
+  it("should save and load a custom name", () => {
+    saveCommanderName("Ace");
+    assert.equal(loadCommanderName(), "Ace");
+  });
+
+  it("should trim whitespace", () => {
+    saveCommanderName("  Rex  ");
+    assert.equal(loadCommanderName(), "Rex");
+  });
+
+  it("should default to 'Commander' for empty string", () => {
+    saveCommanderName("");
+    assert.equal(loadCommanderName(), "Commander");
+  });
+
+  it("should default to 'Commander' for whitespace-only", () => {
+    saveCommanderName("   ");
+    assert.equal(loadCommanderName(), "Commander");
+  });
+
+  it("should truncate to 20 characters", () => {
+    saveCommanderName("a".repeat(30));
+    assert.equal(loadCommanderName().length, 20);
+  });
+
+  it("should report hasCommanderName correctly", () => {
+    assert.equal(hasCommanderName(), false);
+    saveCommanderName("Test");
+    assert.equal(hasCommanderName(), true);
+  });
+
+  it("should be cleared by clearStarterMech", () => {
+    saveCommanderName("Test");
+    saveStarterMech(1);
+    clearStarterMech();
+    assert.equal(hasCommanderName(), false);
+    assert.equal(loadCommanderName(), "Commander");
+  });
+});


### PR DESCRIPTION
## Summary
- Added commander name storage: `saveCommanderName()`/`loadCommanderName()`/`hasCommanderName()` with 20-char limit, defaults to "Commander"
- Added name input field in mech binding overlay (DOM input, optional)
- Lobby shows "Commander: {name}" below title
- Battle HUD shows "{commanderName} — {mechCodename}" for player panel
- `clearStarterMech()` also clears commander name (full identity reset)
- 8 new tests covering all storage operations

## Test plan
- [x] 498/498 tests pass (all green)
- [x] 8 new commander name tests pass
- [ ] Visual verification: name input in binding, name display in lobby/HUD

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)