### PR TITLE
feat: add persistent Combat Core templates for mech personality

### DIFF
--- a/src/data/strategies.ts
+++ b/src/data/strategies.ts
@@ -1,12 +1,12 @@
-/** Starter strategy templates for new player initialization. */
+/** Combat Core templates — persistent mech behavioral identity. */
 
-export interface StrategyTemplate {
+export interface CombatCore {
   name: string;
   icon: string;
   prompt: string;
 }
 
-export const STRATEGY_TEMPLATES: StrategyTemplate[] = [
+export const COMBAT_CORES: CombatCore[] = [
   {
     name: "Aggressive",
     icon: "\u2694\uFE0F",
@@ -26,3 +26,8 @@ export const STRATEGY_TEMPLATES: StrategyTemplate[] = [
       "Prioritize survival. Use Reactive Armor frequently to build up shields. Only attack when HP is above 60%. Prefer resisted attacks over risky super-effective moves.",
   },
 ];
+
+/** @deprecated Use COMBAT_CORES instead */
+export const STRATEGY_TEMPLATES = COMBAT_CORES;
+/** @deprecated Use CombatCore instead */
+export type StrategyTemplate = CombatCore;

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -5,16 +5,18 @@
 import Phaser from "phaser";
 import { ASSET_REGISTRY, preloadAllAssets } from "../assets";
 import { MECH_ROSTER, OPPONENT_MECH } from "../data/mechs";
-import { STRATEGY_TEMPLATES } from "../data/strategies";
+import { COMBAT_CORES } from "../data/strategies";
 import { launchHistoryScene } from "../utils/lazyScene";
 import {
   clearStarterMech,
+  hasCombatCore,
   hasSeenOnboarding,
   hasStarterMech,
+  loadCombatCore,
   loadCommanderName,
-  loadMechPrompt,
   loadStarterMech,
   markOnboardingSeen,
+  saveCombatCore,
   saveCommanderName,
   saveMechPrompt,
   saveStarterMech,
@@ -317,16 +319,15 @@ export class LobbyScene extends Phaser.Scene {
     bg.fillStyle(COLORS.panelBg, 0.6);
     bg.fillRoundedRect(panelX, panelY, panelW, panelH, 6);
 
-    const prompt = loadMechPrompt();
     let label: string;
     let color: string;
 
-    if (prompt.trim()) {
-      const summary = prompt.length > 60 ? `${prompt.slice(0, 57)}...` : prompt;
-      label = `\u26A1 Strategy: ${summary}`;
+    if (hasCombatCore()) {
+      const core = COMBAT_CORES[loadCombatCore()] ?? COMBAT_CORES[0];
+      label = `${core.icon} Combat Core: ${core.name}`;
       color = COLORS.accent;
     } else {
-      label = "No strategy set — enter one in battle to guide your AI";
+      label = "No Combat Core set \u2014 choose one to guide your AI";
       color = COLORS.dimText;
     }
 
@@ -334,9 +335,26 @@ export class LobbyScene extends Phaser.Scene {
       .text(panelX + 12, panelY + panelH / 2, label, {
         fontSize,
         color,
-        wordWrap: { width: panelW - 24 },
+        wordWrap: { width: panelW - 60 },
       })
       .setOrigin(0, 0.5);
+
+    // Change button
+    this.add
+      .text(panelX + panelW - 12, panelY + panelH / 2, "Change", {
+        fontSize: `${Math.max(10, Math.floor(w * 0.013))}px`,
+        color: COLORS.accent,
+      })
+      .setOrigin(1, 0.5);
+
+    const changeZone = this.add
+      .zone(panelX + panelW - 60, panelY, 60, panelH)
+      .setOrigin(0)
+      .setInteractive({ useHandCursor: true });
+
+    changeZone.on("pointerdown", () => {
+      this.showStrategyPicker();
+    });
   }
 
   private drawButtons(w: number, h: number): void {
@@ -677,7 +695,7 @@ export class LobbyScene extends Phaser.Scene {
     // Title
     overlay.add(
       this.add
-        .text(w / 2, h * 0.06, "CHOOSE YOUR STRATEGY", {
+        .text(w / 2, h * 0.06, "CHOOSE YOUR COMBAT CORE", {
           fontSize: `${Math.max(20, Math.floor(w * 0.035))}px`,
           color: COLORS.accent,
           fontStyle: "bold",
@@ -687,7 +705,7 @@ export class LobbyScene extends Phaser.Scene {
 
     overlay.add(
       this.add
-        .text(w / 2, h * 0.11, "Pick a battle style to start with", {
+        .text(w / 2, h * 0.11, "Pick a combat core to guide your AI", {
           fontSize: `${Math.max(12, Math.floor(w * 0.018))}px`,
           color: "#888888",
         })
@@ -710,8 +728,8 @@ export class LobbyScene extends Phaser.Scene {
         obj.destroy();
       }
 
-      for (let i = 0; i < STRATEGY_TEMPLATES.length; i++) {
-        const tmpl = STRATEGY_TEMPLATES[i];
+      for (let i = 0; i < COMBAT_CORES.length; i++) {
+        const tmpl = COMBAT_CORES[i];
         const y = startY + i * (cardH + gap);
         const isSelected = i === pickerIndex;
 
@@ -769,7 +787,7 @@ export class LobbyScene extends Phaser.Scene {
     const btnW = Math.min(w * 0.5, 220);
     const btnH = 44;
     const btnX = w / 2 - btnW / 2;
-    const btnY = startY + STRATEGY_TEMPLATES.length * (cardH + gap) + 12;
+    const btnY = startY + COMBAT_CORES.length * (cardH + gap) + 12;
 
     const confirmBg = this.add.graphics();
     confirmBg.fillStyle(COLORS.accentHex, 1);
@@ -778,7 +796,7 @@ export class LobbyScene extends Phaser.Scene {
 
     overlay.add(
       this.add
-        .text(w / 2, btnY + btnH / 2, "Use This Strategy", {
+        .text(w / 2, btnY + btnH / 2, "Activate Core", {
           fontSize: `${Math.max(15, Math.floor(w * 0.023))}px`,
           color: "#000000",
           fontStyle: "bold",
@@ -802,8 +820,10 @@ export class LobbyScene extends Phaser.Scene {
       confirmBg.fillRoundedRect(btnX, btnY, btnW, btnH, 8);
     });
     confirmZone.on("pointerdown", () => {
-      saveMechPrompt(STRATEGY_TEMPLATES[pickerIndex].prompt);
+      saveCombatCore(pickerIndex);
+      saveMechPrompt(COMBAT_CORES[pickerIndex].prompt);
       overlay.destroy();
+      this.buildUI(w, h);
 
       if (!hasSeenOnboarding()) {
         this.showOnboarding();

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -236,6 +236,7 @@ export function clearStarterMech(): void {
   localStorage.removeItem(STARTER_MECH_KEY);
   localStorage.removeItem(ONBOARDING_KEY);
   localStorage.removeItem(COMMANDER_NAME_KEY);
+  localStorage.removeItem(COMBAT_CORE_KEY);
 }
 
 // --- Commander Name ---
@@ -255,4 +256,23 @@ export function saveCommanderName(name: string): void {
 
 export function hasCommanderName(): boolean {
   return localStorage.getItem(COMMANDER_NAME_KEY) !== null;
+}
+
+// --- Combat Core ---
+
+const COMBAT_CORE_KEY = "mechArena_combatCore";
+
+export function saveCombatCore(index: number): void {
+  localStorage.setItem(COMBAT_CORE_KEY, String(index));
+}
+
+export function loadCombatCore(): number {
+  const val = localStorage.getItem(COMBAT_CORE_KEY);
+  if (val === null) return 0;
+  const idx = Number.parseInt(val, 10);
+  return Number.isNaN(idx) ? 0 : idx;
+}
+
+export function hasCombatCore(): boolean {
+  return localStorage.getItem(COMBAT_CORE_KEY) !== null;
 }

--- a/tests/combatCore.test.ts
+++ b/tests/combatCore.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { COMBAT_CORES } from "../src/data/strategies";
+
+// Mock localStorage
+class MockStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+const mockStorage = new MockStorage();
+(globalThis as Record<string, unknown>).localStorage = mockStorage;
+
+const {
+  clearStarterMech,
+  hasCombatCore,
+  loadCombatCore,
+  saveCombatCore,
+  saveStarterMech,
+} = await import("../src/utils/storage");
+
+describe("combat core storage", () => {
+  afterEach(() => {
+    mockStorage.clear();
+  });
+
+  it("should default to index 0 when no core saved", () => {
+    assert.equal(loadCombatCore(), 0);
+  });
+
+  it("should save and load a core index", () => {
+    saveCombatCore(2);
+    assert.equal(loadCombatCore(), 2);
+  });
+
+  it("should report hasCombatCore correctly", () => {
+    assert.equal(hasCombatCore(), false);
+    saveCombatCore(1);
+    assert.equal(hasCombatCore(), true);
+  });
+
+  it("should persist index 0 as a valid selection", () => {
+    saveCombatCore(0);
+    assert.equal(hasCombatCore(), true);
+    assert.equal(loadCombatCore(), 0);
+  });
+
+  it("should handle corrupted value gracefully", () => {
+    mockStorage.setItem("mechArena_combatCore", "invalid");
+    assert.equal(loadCombatCore(), 0);
+  });
+
+  it("should be cleared by clearStarterMech", () => {
+    saveCombatCore(2);
+    saveStarterMech(1);
+    clearStarterMech();
+    assert.equal(hasCombatCore(), false);
+    assert.equal(loadCombatCore(), 0);
+  });
+});
+
+describe("COMBAT_CORES data", () => {
+  it("should have at least 3 cores", () => {
+    assert.ok(COMBAT_CORES.length >= 3);
+  });
+
+  it("each core should have name, icon, and prompt", () => {
+    for (const core of COMBAT_CORES) {
+      assert.ok(core.name.length > 0);
+      assert.ok(core.icon.length > 0);
+      assert.ok(core.prompt.length > 30);
+    }
+  });
+
+  it("core names should be unique", () => {
+    const names = COMBAT_CORES.map((c) => c.name);
+    assert.equal(new Set(names).size, names.length);
+  });
+
+  it("should include Aggressive, Balanced, Defensive", () => {
+    assert.ok(COMBAT_CORES.some((c) => c.name === "Aggressive"));
+    assert.ok(COMBAT_CORES.some((c) => c.name === "Balanced"));
+    assert.ok(COMBAT_CORES.some((c) => c.name === "Defensive"));
+  });
+});

--- a/tests/strategyTemplates.test.ts
+++ b/tests/strategyTemplates.test.ts
@@ -1,14 +1,14 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { STRATEGY_TEMPLATES } from "../src/data/strategies";
+import { COMBAT_CORES } from "../src/data/strategies";
 
-describe("STRATEGY_TEMPLATES", () => {
+describe("COMBAT_CORES", () => {
   it("should contain at least 3 templates", () => {
-    assert.ok(STRATEGY_TEMPLATES.length >= 3);
+    assert.ok(COMBAT_CORES.length >= 3);
   });
 
   it("each template should have name, icon, and prompt", () => {
-    for (const tmpl of STRATEGY_TEMPLATES) {
+    for (const tmpl of COMBAT_CORES) {
       assert.ok(tmpl.name.length > 0, "name should not be empty");
       assert.ok(tmpl.icon.length > 0, "icon should not be empty");
       assert.ok(tmpl.prompt.length > 0, "prompt should not be empty");
@@ -16,30 +16,30 @@ describe("STRATEGY_TEMPLATES", () => {
   });
 
   it("should include Aggressive template", () => {
-    assert.ok(STRATEGY_TEMPLATES.some((t) => t.name === "Aggressive"));
+    assert.ok(COMBAT_CORES.some((t) => t.name === "Aggressive"));
   });
 
   it("should include Balanced template", () => {
-    assert.ok(STRATEGY_TEMPLATES.some((t) => t.name === "Balanced"));
+    assert.ok(COMBAT_CORES.some((t) => t.name === "Balanced"));
   });
 
   it("should include Defensive template", () => {
-    assert.ok(STRATEGY_TEMPLATES.some((t) => t.name === "Defensive"));
+    assert.ok(COMBAT_CORES.some((t) => t.name === "Defensive"));
   });
 
   it("template names should be unique", () => {
-    const names = STRATEGY_TEMPLATES.map((t) => t.name);
+    const names = COMBAT_CORES.map((t) => t.name);
     assert.equal(new Set(names).size, names.length);
   });
 
   it("prompts should be non-trivial (> 30 chars)", () => {
-    for (const tmpl of STRATEGY_TEMPLATES) {
+    for (const tmpl of COMBAT_CORES) {
       assert.ok(tmpl.prompt.length > 30, `${tmpl.name} prompt too short`);
     }
   });
 
   it("prompts should be within 500 char limit", () => {
-    for (const tmpl of STRATEGY_TEMPLATES) {
+    for (const tmpl of COMBAT_CORES) {
       assert.ok(
         tmpl.prompt.length <= 500,
         `${tmpl.name} prompt exceeds 500 chars`,
@@ -50,7 +50,7 @@ describe("STRATEGY_TEMPLATES", () => {
 
 describe("strategy template content", () => {
   it("Aggressive should mention high damage", () => {
-    const tmpl = STRATEGY_TEMPLATES.find((t) => t.name === "Aggressive");
+    const tmpl = COMBAT_CORES.find((t) => t.name === "Aggressive");
     assert.ok(tmpl);
     assert.ok(
       tmpl.prompt.toLowerCase().includes("damage") ||
@@ -59,7 +59,7 @@ describe("strategy template content", () => {
   });
 
   it("Balanced should mention both offense and defense", () => {
-    const tmpl = STRATEGY_TEMPLATES.find((t) => t.name === "Balanced");
+    const tmpl = COMBAT_CORES.find((t) => t.name === "Balanced");
     assert.ok(tmpl);
     assert.ok(tmpl.prompt.toLowerCase().includes("defense"));
     assert.ok(
@@ -69,7 +69,7 @@ describe("strategy template content", () => {
   });
 
   it("Defensive should mention survival or defense", () => {
-    const tmpl = STRATEGY_TEMPLATES.find((t) => t.name === "Defensive");
+    const tmpl = COMBAT_CORES.find((t) => t.name === "Defensive");
     assert.ok(tmpl);
     assert.ok(
       tmpl.prompt.toLowerCase().includes("defense") ||


### PR DESCRIPTION
## Summary
- Renamed STRATEGY_TEMPLATES → COMBAT_CORES, StrategyTemplate → CombatCore (backward-compat aliases)
- Added `saveCombatCore()`/`loadCombatCore()`/`hasCombatCore()` storage functions
- Strategy picker renamed to "CHOOSE YOUR COMBAT CORE", saves both index and prompt
- Lobby shows current Combat Core (icon + name) with "Change" button for anytime switching
- `clearStarterMech()` also clears combat core
- 10 new tests covering core storage and data validation

## Test plan
- [x] 508/508 tests pass (all green)
- [x] 10 new combat core tests pass
- [ ] Visual verification: Combat Core display in lobby, Change button works

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)