### PR TITLE
feat: integrate Combat Core into battle decision behavior

### DIFF
--- a/api/battle.ts
+++ b/api/battle.ts
@@ -15,6 +15,7 @@ interface BattleRequest {
     lastMove: string;
     statusEffects: string[];
     skills?: Array<{ name: string; type: string; damage: number }>;
+    combatCore?: { name: string; prompt: string };
   };
 }
 
@@ -66,17 +67,25 @@ function isMockMode(): boolean {
 export function mockBattleResponse(body: BattleRequest): BattleResponse {
   const { gameState } = body;
   const hpRatio = gameState.playerHP / 100;
+  const coreName = gameState.combatCore?.name?.toLowerCase() ?? "balanced";
 
-  // Low HP → 50% chance to use defense
-  if (hpRatio < 0.3 && Math.random() < 0.5) {
+  // Low HP → defense chance varies by core
+  const defenseThreshold =
+    coreName === "defensive" ? 0.8 : coreName === "aggressive" ? 0.2 : 0.5;
+  if (hpRatio < 0.3 && Math.random() < defenseThreshold) {
     return {
       move: 3,
-      reasoning: "[MOCK] HP critical — activating Reactive Armor",
+      reasoning: `[MOCK] HP critical — activating Reactive Armor (${coreName})`,
     };
   }
 
-  // Weighted random favoring attack skills (indices 0-2)
-  const weights = [0.4, 0.3, 0.2, 0.1];
+  // Weighted random — adjust by combat core personality
+  const weights =
+    coreName === "aggressive"
+      ? [0.5, 0.25, 0.2, 0.05]
+      : coreName === "defensive"
+        ? [0.2, 0.2, 0.2, 0.4]
+        : [0.4, 0.3, 0.2, 0.1];
   const roll = Math.random();
   let cumulative = 0;
   for (let i = 0; i < weights.length; i++) {
@@ -107,10 +116,17 @@ export function buildPrompt(body: BattleRequest): string {
         .join("\n")
     : "Skills not available";
 
-  return `You are an AI controlling a battle mech. The player has given you this strategy:
-"${mechPrompt}"
+  const coreSection = gameState.combatCore
+    ? `Base combat personality (${gameState.combatCore.name}): "${gameState.combatCore.prompt}"\n\n`
+    : "";
 
-Current game state:
+  const playerSection = mechPrompt.trim()
+    ? `Additional player instructions: "${mechPrompt}"\n\n`
+    : "";
+
+  return `You are an AI controlling a battle mech.
+
+${coreSection}${playerSection}Current game state:
 - Your HP: ${gameState.playerHP}
 - Opponent HP: ${gameState.opponentHP}
 - Opponent's last move: ${gameState.lastMove || "none"}

--- a/src/api/battleClient.ts
+++ b/src/api/battleClient.ts
@@ -1,6 +1,8 @@
 /** Battle API client - calls /api/battle for AI move selection */
 
+import { COMBAT_CORES } from "../data/strategies";
 import type { BattleState } from "../types/game";
+import { loadCombatCore } from "../utils/storage";
 
 interface BattleAPIRequest {
   mechPrompt: string;
@@ -10,6 +12,7 @@ interface BattleAPIRequest {
     lastMove: string;
     statusEffects: string[];
     skills: Array<{ name: string; type: string; damage: number }>;
+    combatCore?: { name: string; prompt: string };
   };
 }
 
@@ -37,6 +40,10 @@ function buildRequestBody(
         type: String(s.type),
         damage: s.damage,
       })),
+      combatCore: (() => {
+        const core = COMBAT_CORES[loadCombatCore()];
+        return core ? { name: core.name, prompt: core.prompt } : undefined;
+      })(),
     },
   };
 }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -267,10 +267,14 @@ export function saveCombatCore(index: number): void {
 }
 
 export function loadCombatCore(): number {
-  const val = localStorage.getItem(COMBAT_CORE_KEY);
-  if (val === null) return 0;
-  const idx = Number.parseInt(val, 10);
-  return Number.isNaN(idx) ? 0 : idx;
+  try {
+    const val = localStorage.getItem(COMBAT_CORE_KEY);
+    if (val === null) return 0;
+    const idx = Number.parseInt(val, 10);
+    return Number.isNaN(idx) ? 0 : idx;
+  } catch {
+    return 0;
+  }
 }
 
 export function hasCombatCore(): boolean {

--- a/tests/battle-api.test.ts
+++ b/tests/battle-api.test.ts
@@ -94,6 +94,53 @@ describe("buildPrompt", () => {
 
     assert.ok(prompt.includes("Skills not available"));
   });
+
+  it("should include Combat Core personality when provided", () => {
+    const prompt = buildPrompt({
+      mechPrompt: "Focus fire",
+      gameState: {
+        playerHP: 100,
+        opponentHP: 100,
+        lastMove: "",
+        statusEffects: [],
+        skills: TEST_SKILLS,
+        combatCore: { name: "Aggressive", prompt: "Always attack first" },
+      },
+    });
+
+    assert.ok(prompt.includes("Aggressive"), "should contain core name");
+    assert.ok(
+      prompt.includes("Always attack first"),
+      "should contain core prompt",
+    );
+    assert.ok(
+      prompt.includes("Focus fire"),
+      "should still contain player instructions",
+    );
+    assert.ok(
+      prompt.includes("Base combat personality"),
+      "should have personality section",
+    );
+    assert.ok(
+      prompt.includes("Additional player instructions"),
+      "should have player section",
+    );
+  });
+
+  it("should work without Combat Core (backward compat)", () => {
+    const prompt = buildPrompt({
+      mechPrompt: "test",
+      gameState: {
+        playerHP: 100,
+        opponentHP: 100,
+        lastMove: "",
+        statusEffects: [],
+        skills: TEST_SKILLS,
+      },
+    });
+
+    assert.ok(!prompt.includes("Base combat personality"));
+  });
 });
 
 describe("parseResponse", () => {

--- a/tests/battleClient.test.ts
+++ b/tests/battleClient.test.ts
@@ -1,5 +1,17 @@
 import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it, mock } from "node:test";
+
+// Mock localStorage before importing modules that use it
+if (typeof globalThis.localStorage === "undefined") {
+  const store = new Map<string, string>();
+  (globalThis as Record<string, unknown>).localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => store.set(k, v),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear(),
+  };
+}
+
 import { callBattleAPI } from "../src/api/battleClient";
 import type { BattleState } from "../src/types/game";
 import { MechType, TurnPhase } from "../src/types/game";


### PR DESCRIPTION
## Summary
- Client sends `combatCore` (name + prompt) from storage in API request
- `buildPrompt()` now has two-layer strategy: Combat Core as base personality + user prompt as additional instructions
- Mock API adjusts skill weights by core personality (Aggressive→attack, Defensive→defense)
- `loadCombatCore()` safe with try-catch for non-browser environments
- 2 new tests: Combat Core in prompt integration, backward compatibility

## Test plan
- [x] 510/510 tests pass (all green)
- [x] buildPrompt includes Combat Core personality section
- [x] Backward compatible when combatCore is absent

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)