### PR TITLE
feat: store mech identity and Combat Core in battle history

### DIFF
--- a/src/scenes/HistoryScene.ts
+++ b/src/scenes/HistoryScene.ts
@@ -425,6 +425,32 @@ export class HistoryScene extends Phaser.Scene {
     this.detailOverlay.add(title);
     y += lineH + 10;
 
+    // Mech identity
+    if (record.playerMechCodename) {
+      this.detailOverlay.add(
+        this.add
+          .text(cx, y, `Mech: ${record.playerMechCodename}`, {
+            fontSize,
+            color: COLORS.accent,
+          })
+          .setOrigin(0.5, 0),
+      );
+      y += lineH;
+    }
+
+    // Combat Core
+    if (record.combatCoreName) {
+      this.detailOverlay.add(
+        this.add
+          .text(cx, y, `Core: ${record.combatCoreName}`, {
+            fontSize,
+            color: COLORS.dimText,
+          })
+          .setOrigin(0.5, 0),
+      );
+      y += lineH;
+    }
+
     // Matchup
     const matchup = `${record.playerMechType.toUpperCase()} vs ${record.opponentMechType.toUpperCase()}`;
     this.detailOverlay.add(

--- a/src/scenes/battle/BattleResult.ts
+++ b/src/scenes/battle/BattleResult.ts
@@ -4,11 +4,12 @@
 
 import type Phaser from "phaser";
 import { OPPONENT_MECH } from "../../data/mechs";
+import { COMBAT_CORES } from "../../data/strategies";
 import type { Mech } from "../../types/game";
 import type { BattleRecord } from "../../types/storage";
 import type { BattleManager } from "../../utils/BattleManager";
 import { launchHistoryScene } from "../../utils/lazyScene";
-import { saveBattleHistory } from "../../utils/storage";
+import { loadCombatCore, saveBattleHistory } from "../../utils/storage";
 import {
   isMuted,
   loadSettings,
@@ -143,6 +144,8 @@ export function saveBattleRecord(
     opponentHpLeft: state.opponent.hp,
     prompt: mechPrompt.trim() || undefined,
     battleLog: state.log.slice(0, 100),
+    playerMechCodename: playerMech.codename,
+    combatCoreName: COMBAT_CORES[loadCombatCore()]?.name,
   };
   saveBattleHistory(record);
 }

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -13,6 +13,8 @@ export interface BattleRecord {
   opponentHpLeft: number;
   prompt?: string;
   battleLog?: string[];
+  playerMechCodename?: string;
+  combatCoreName?: string;
 }
 
 export interface GameSettings {

--- a/tests/historyIdentity.test.ts
+++ b/tests/historyIdentity.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { BattleRecord } from "../src/types/storage";
+
+function makeRecord(overrides?: Partial<BattleRecord>): BattleRecord {
+  return {
+    id: "test-id",
+    timestamp: Date.now(),
+    playerMechType: "kinetic" as BattleRecord["playerMechType"],
+    opponentMechType: "beam" as BattleRecord["opponentMechType"],
+    result: "win",
+    turns: 3,
+    playerHpLeft: 55,
+    opponentHpLeft: 0,
+    ...overrides,
+  };
+}
+
+describe("BattleRecord identity fields", () => {
+  it("should support playerMechCodename", () => {
+    const record = makeRecord({ playerMechCodename: "FALCON UNIT" });
+    assert.equal(record.playerMechCodename, "FALCON UNIT");
+  });
+
+  it("should support combatCoreName", () => {
+    const record = makeRecord({ combatCoreName: "Aggressive" });
+    assert.equal(record.combatCoreName, "Aggressive");
+  });
+
+  it("should allow both fields undefined for backward compat", () => {
+    const record = makeRecord();
+    assert.equal(record.playerMechCodename, undefined);
+    assert.equal(record.combatCoreName, undefined);
+  });
+
+  it("should store both identity fields together", () => {
+    const record = makeRecord({
+      playerMechCodename: "HYDRA SENTINEL",
+      combatCoreName: "Defensive",
+    });
+    assert.equal(record.playerMechCodename, "HYDRA SENTINEL");
+    assert.equal(record.combatCoreName, "Defensive");
+  });
+
+  it("should coexist with existing optional fields", () => {
+    const record = makeRecord({
+      prompt: "test prompt",
+      battleLog: ["[TURN]--- Battle Start ---"],
+      playerMechCodename: "VOLT STRIKER",
+      combatCoreName: "Balanced",
+    });
+    assert.equal(record.prompt, "test prompt");
+    assert.ok(Array.isArray(record.battleLog));
+    assert.equal(record.playerMechCodename, "VOLT STRIKER");
+    assert.equal(record.combatCoreName, "Balanced");
+  });
+});
+
+describe("history detail display logic", () => {
+  function getIdentityLines(
+    record: BattleRecord,
+  ): Array<{ label: string; value: string }> {
+    const lines: Array<{ label: string; value: string }> = [];
+    if (record.playerMechCodename) {
+      lines.push({ label: "Mech", value: record.playerMechCodename });
+    }
+    if (record.combatCoreName) {
+      lines.push({ label: "Core", value: record.combatCoreName });
+    }
+    return lines;
+  }
+
+  it("should show mech codename when present", () => {
+    const lines = getIdentityLines(
+      makeRecord({ playerMechCodename: "FALCON UNIT" }),
+    );
+    assert.equal(lines.length, 1);
+    assert.equal(lines[0].label, "Mech");
+    assert.equal(lines[0].value, "FALCON UNIT");
+  });
+
+  it("should show combat core when present", () => {
+    const lines = getIdentityLines(
+      makeRecord({ combatCoreName: "Aggressive" }),
+    );
+    assert.equal(lines.length, 1);
+    assert.equal(lines[0].label, "Core");
+  });
+
+  it("should show both when both present", () => {
+    const lines = getIdentityLines(
+      makeRecord({
+        playerMechCodename: "HYDRA SENTINEL",
+        combatCoreName: "Defensive",
+      }),
+    );
+    assert.equal(lines.length, 2);
+  });
+
+  it("should show nothing for old records without identity", () => {
+    const lines = getIdentityLines(makeRecord());
+    assert.equal(lines.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- Added `playerMechCodename` and `combatCoreName` optional fields to BattleRecord
- `saveBattleRecord()` now saves mech codename and Combat Core name into each record
- HistoryScene detail panel shows "Mech: {codename}" and "Core: {coreName}" when present
- Old records without these fields display normally (backward compatible)
- 9 new tests covering field support, backward compat, display logic

## Test plan
- [x] 519/519 tests pass (all green)
- [x] 9 new identity tests pass
- [ ] Visual verification: detail panel shows mech and core info

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)