### PR TITLE
feat: enforce skin cosmetic separation from combat behavior (#149)

### DIFF
--- a/api/battle.ts
+++ b/api/battle.ts
@@ -107,6 +107,14 @@ export function mockBattleResponse(body: BattleRequest): BattleResponse {
   return { move: 0, reasoning: "[MOCK] Default attack" };
 }
 
+/**
+ * Build the Claude prompt from combat-only inputs.
+ *
+ * Inputs: combatCore.prompt (behavioral personality), mechPrompt (player
+ * free-text strategy), and gameState (HP, skills, status effects).
+ * Skin/cosmetic data is intentionally excluded — skins do not influence
+ * AI decision-making.
+ */
 export function buildPrompt(body: BattleRequest): string {
   const { mechPrompt, gameState } = body;
 

--- a/docs/SKIN_SEPARATION.md
+++ b/docs/SKIN_SEPARATION.md
@@ -1,0 +1,57 @@
+# Skin Separation: Cosmetic vs Combat Behavior
+
+## Principle
+
+Skins are **cosmetic only**. They change the visual appearance of a mech (sprites, portraits, thumbnails) but have **no effect** on combat stats, AI decisions, or battle outcomes.
+
+## Architecture
+
+```
+Cosmetic Layer (Skins)          Behavior Layer (Combat)
+┌─────────────────────┐        ┌──────────────────────┐
+│ SkinPackManifest     │        │ MECH_ROSTER          │
+│  - id, name          │        │  - hp, maxHp, skills │
+│  - codename          │        │  - type, damage      │
+│  - themeColor        │        ├──────────────────────┤
+│  - baseType (visual) │        │ CombatCore           │
+├─────────────────────┤        │  - name, prompt      │
+│ SkinPack             │        ├──────────────────────┤
+│  - mechSprite        │        │ mechPrompt           │
+│  - portraits         │        │  (player free text)  │
+│  - thumbnail         │        └──────────┬───────────┘
+└──────────┬──────────┘                    │
+           │                               ▼
+           ▼                        buildPrompt() → Claude API
+    Phaser rendering                       │
+    (visual only,                          ▼
+     never sent to API)            AI move decision
+```
+
+## Rules
+
+1. **SkinPack types** (`src/types/skin.ts`) must only contain visual/identity fields. Never add `hp`, `damage`, `skills`, or any combat modifier.
+
+2. **Battle API request** (`src/api/battleClient.ts`) must never include `skinId` or any skin-related data. The `buildRequestBody` function only sends `mechPrompt`, `gameState` (HP, skills, status effects), and `combatCore`.
+
+3. **Prompt construction** (`api/battle.ts`) must only use `combatCore.prompt`, `mechPrompt`, and `gameState`. Skin names or identifiers must not appear in the AI prompt.
+
+4. **UI wording** must present skins as "Appearance" — a visual/cosmetic choice. Avoid terms like "upgrade", "enhance", or "power" in skin-related UI.
+
+## What Drives Battle Behavior
+
+| Source | What it controls |
+|--------|-----------------|
+| `MECH_ROSTER` | Base stats: HP, skills, damage values, type |
+| `CombatCore` | AI personality: aggressive/balanced/defensive prompt |
+| `mechPrompt` | Player's free-text tactical instructions |
+| `BattleManager` | Type effectiveness, damage calculation, win condition |
+
+## Future: If Skins Need Combat Effects
+
+If a future design decision requires skins to influence combat:
+
+1. Create a new `SkinCombatModifier` interface (separate from `SkinPack`)
+2. Add a migration path that keeps existing skins backward-compatible
+3. Update `buildRequestBody` to include modifier data
+4. Update `buildPrompt` to communicate modifiers to the AI
+5. Update this document and all related tests

--- a/src/api/battleClient.ts
+++ b/src/api/battleClient.ts
@@ -23,7 +23,14 @@ interface BattleAPIResponse {
 
 const MAX_RETRIES = 2;
 
-function buildRequestBody(
+/**
+ * Build the request body for the battle API.
+ *
+ * IMPORTANT: Only combat-relevant data (HP, skills, combatCore, mechPrompt)
+ * is included. Skin/cosmetic data (skinId, skin name, etc.) must NEVER be
+ * sent to the API — skins are purely visual and do not affect battle behavior.
+ */
+export function buildRequestBody(
   prompt: string,
   state: BattleState,
 ): BattleAPIRequest {

--- a/src/scenes/LobbyScene.ts
+++ b/src/scenes/LobbyScene.ts
@@ -329,7 +329,7 @@ export class LobbyScene extends Phaser.Scene {
     const skinName = skin ? skin.name : "Standard Issue";
 
     this.add
-      .text(panelX + 12, panelY + panelH / 2, `Skin: ${skinName}`, {
+      .text(panelX + 12, panelY + panelH / 2, `Appearance: ${skinName}`, {
         fontSize,
         color: COLORS.dimText,
       })
@@ -545,7 +545,7 @@ export class LobbyScene extends Phaser.Scene {
 
     overlay.add(
       this.add
-        .text(w / 2, h * 0.06, "SELECT SKIN", {
+        .text(w / 2, h * 0.06, "SELECT APPEARANCE", {
           fontSize: `${Math.max(18, Math.floor(w * 0.03))}px`,
           color: COLORS.accent,
           fontStyle: "bold",
@@ -646,7 +646,7 @@ export class LobbyScene extends Phaser.Scene {
 
     overlay.add(
       this.add
-        .text(w / 2, btnY + btnH / 2, "Apply Skin", {
+        .text(w / 2, btnY + btnH / 2, "Apply Appearance", {
           fontSize: `${Math.max(15, Math.floor(w * 0.023))}px`,
           color: "#000000",
           fontStyle: "bold",

--- a/src/types/skin.ts
+++ b/src/types/skin.ts
@@ -10,7 +10,13 @@
 
 import type { MechType } from "./game";
 
-/** Manifest metadata for a skin pack (stored in manifest.json). */
+/**
+ * Manifest metadata for a skin pack (stored in manifest.json).
+ *
+ * COSMETIC ONLY — skin packs must never contain combat-related fields
+ * (hp, damage, skills, type effectiveness, etc.). All battle behavior
+ * is driven exclusively by Combat Core and player prompt.
+ */
 export interface SkinPackManifest {
   /** Unique identifier for this skin (kebab-case). */
   id: string;
@@ -24,7 +30,12 @@ export interface SkinPackManifest {
   baseType: MechType;
 }
 
-/** Runtime representation of a loaded skin pack with asset paths. */
+/**
+ * Runtime representation of a loaded skin pack with asset paths.
+ *
+ * COSMETIC ONLY — extends SkinPackManifest with visual asset paths only.
+ * No combat stats, no behavioral modifiers.
+ */
 export interface SkinPack extends SkinPackManifest {
   /** Path to battle sprite (256×256 PNG). */
   mechSprite: string;

--- a/tests/skinSeparation.test.ts
+++ b/tests/skinSeparation.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, it, mock, beforeEach, afterEach } from "node:test";
+import { afterEach, beforeEach, describe, it, mock } from "node:test";
 
 // Mock localStorage before importing modules that use it
 if (typeof globalThis.localStorage === "undefined") {
@@ -12,11 +12,11 @@ if (typeof globalThis.localStorage === "undefined") {
   };
 }
 
-import { buildRequestBody } from "../src/api/battleClient";
 import { buildPrompt } from "../api/battle.ts";
+import { buildRequestBody } from "../src/api/battleClient";
 import type { BattleState } from "../src/types/game";
 import { MechType, TurnPhase } from "../src/types/game";
-import type { SkinPackManifest, SkinPack } from "../src/types/skin";
+import type { SkinPack, SkinPackManifest } from "../src/types/skin";
 
 function makeGameState(overrides?: Partial<BattleState>): BattleState {
   return {
@@ -70,9 +70,20 @@ describe("skin separation — SkinPack types are cosmetic only", () => {
     assert.ok(manifest.baseType);
     // Ensure no combat fields are present at runtime
     const keys = Object.keys(manifest);
-    const combatFields = ["hp", "maxHp", "damage", "skills", "defense", "attack", "power"];
+    const combatFields = [
+      "hp",
+      "maxHp",
+      "damage",
+      "skills",
+      "defense",
+      "attack",
+      "power",
+    ];
     for (const field of combatFields) {
-      assert.ok(!keys.includes(field), `SkinPackManifest must not contain combat field: ${field}`);
+      assert.ok(
+        !keys.includes(field),
+        `SkinPackManifest must not contain combat field: ${field}`,
+      );
     }
   });
 
@@ -92,9 +103,20 @@ describe("skin separation — SkinPack types are cosmetic only", () => {
       thumbnail: "/assets/skins/test/thumbnail.png",
     };
     const keys = Object.keys(pack);
-    const combatFields = ["hp", "maxHp", "damage", "skills", "defense", "attack", "power"];
+    const combatFields = [
+      "hp",
+      "maxHp",
+      "damage",
+      "skills",
+      "defense",
+      "attack",
+      "power",
+    ];
     for (const field of combatFields) {
-      assert.ok(!keys.includes(field), `SkinPack must not contain combat field: ${field}`);
+      assert.ok(
+        !keys.includes(field),
+        `SkinPack must not contain combat field: ${field}`,
+      );
     }
   });
 });
@@ -116,11 +138,26 @@ describe("skin separation — buildRequestBody excludes skin data", () => {
     const json = JSON.stringify(body);
     // Skin fields must not appear in the request body
     assert.ok(!json.includes("skinId"), "request body must not contain skinId");
-    assert.ok(!json.includes("skinName"), "request body must not contain skinName");
-    assert.ok(!json.includes("themeColor"), "request body must not contain themeColor");
-    assert.ok(!json.includes("mechSprite"), "request body must not contain mechSprite");
-    assert.ok(!json.includes("thumbnail"), "request body must not contain thumbnail");
-    assert.ok(!json.includes("portrait"), "request body must not contain portrait");
+    assert.ok(
+      !json.includes("skinName"),
+      "request body must not contain skinName",
+    );
+    assert.ok(
+      !json.includes("themeColor"),
+      "request body must not contain themeColor",
+    );
+    assert.ok(
+      !json.includes("mechSprite"),
+      "request body must not contain mechSprite",
+    );
+    assert.ok(
+      !json.includes("thumbnail"),
+      "request body must not contain thumbnail",
+    );
+    assert.ok(
+      !json.includes("portrait"),
+      "request body must not contain portrait",
+    );
   });
 
   it("request body should only contain combat-relevant fields", () => {
@@ -130,7 +167,14 @@ describe("skin separation — buildRequestBody excludes skin data", () => {
     assert.deepEqual(topKeys.sort(), ["gameState", "mechPrompt"]);
     // gameState keys
     const gsKeys = Object.keys(body.gameState);
-    const expected = ["combatCore", "lastMove", "opponentHP", "playerHP", "skills", "statusEffects"];
+    const expected = [
+      "combatCore",
+      "lastMove",
+      "opponentHP",
+      "playerHP",
+      "skills",
+      "statusEffects",
+    ];
     assert.deepEqual(gsKeys.sort(), expected);
   });
 });
@@ -154,12 +198,27 @@ describe("skin separation — buildPrompt excludes skin data", () => {
       },
     });
     // Prompt should not reference skins
-    assert.ok(!prompt.toLowerCase().includes("skin"), "prompt must not mention 'skin'");
-    assert.ok(!prompt.toLowerCase().includes("cosmetic"), "prompt must not mention 'cosmetic'");
-    assert.ok(!prompt.toLowerCase().includes("appearance"), "prompt must not mention 'appearance'");
+    assert.ok(
+      !prompt.toLowerCase().includes("skin"),
+      "prompt must not mention 'skin'",
+    );
+    assert.ok(
+      !prompt.toLowerCase().includes("cosmetic"),
+      "prompt must not mention 'cosmetic'",
+    );
+    assert.ok(
+      !prompt.toLowerCase().includes("appearance"),
+      "prompt must not mention 'appearance'",
+    );
     // Prompt should contain combat data
-    assert.ok(prompt.includes("Aggressive"), "prompt should include combat core name");
-    assert.ok(prompt.includes("Focus fire"), "prompt should include player instructions");
+    assert.ok(
+      prompt.includes("Aggressive"),
+      "prompt should include combat core name",
+    );
+    assert.ok(
+      prompt.includes("Focus fire"),
+      "prompt should include player instructions",
+    );
     assert.ok(prompt.includes("80"), "prompt should include player HP");
   });
 

--- a/tests/skinSeparation.test.ts
+++ b/tests/skinSeparation.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { describe, it, mock, beforeEach, afterEach } from "node:test";
+
+// Mock localStorage before importing modules that use it
+if (typeof globalThis.localStorage === "undefined") {
+  const store = new Map<string, string>();
+  (globalThis as Record<string, unknown>).localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => store.set(k, v),
+    removeItem: (k: string) => store.delete(k),
+    clear: () => store.clear(),
+  };
+}
+
+import { buildRequestBody } from "../src/api/battleClient";
+import { buildPrompt } from "../api/battle.ts";
+import type { BattleState } from "../src/types/game";
+import { MechType, TurnPhase } from "../src/types/game";
+import type { SkinPackManifest, SkinPack } from "../src/types/skin";
+
+function makeGameState(overrides?: Partial<BattleState>): BattleState {
+  return {
+    player: {
+      name: "PlayerMech",
+      type: MechType.Kinetic,
+      hp: 80,
+      maxHp: 100,
+      skills: [
+        { name: "Railgun Salvo", type: MechType.Kinetic, damage: 40 },
+        { name: "Plasma Beam", type: MechType.Beam, damage: 30 },
+        { name: "EMP Pulse", type: MechType.Emp, damage: 25 },
+        { name: "Reactive Armor", type: "defense", damage: 0 },
+      ],
+    },
+    opponent: {
+      name: "EnemyMech",
+      type: MechType.Beam,
+      hp: 60,
+      maxHp: 100,
+      skills: [
+        { name: "Plasma Beam", type: MechType.Beam, damage: 30 },
+        { name: "Railgun Salvo", type: MechType.Kinetic, damage: 40 },
+        { name: "EMP Pulse", type: MechType.Emp, damage: 25 },
+        { name: "Reactive Armor", type: "defense", damage: 0 },
+      ],
+    },
+    phase: TurnPhase.AiThinking,
+    log: ["[EFF]PlayerMech used Fire Blast!"],
+    turnCount: 1,
+    winner: null,
+    ...overrides,
+  };
+}
+
+describe("skin separation — SkinPack types are cosmetic only", () => {
+  it("SkinPackManifest should not contain combat fields", () => {
+    // Verify the type contract: only visual/identity fields exist
+    const manifest: SkinPackManifest = {
+      id: "test-skin",
+      name: "Test Skin",
+      codename: "FALCON UNIT",
+      themeColor: "#FF0000",
+      baseType: MechType.Kinetic,
+    };
+    // These fields should exist
+    assert.ok(manifest.id);
+    assert.ok(manifest.name);
+    assert.ok(manifest.codename);
+    assert.ok(manifest.themeColor);
+    assert.ok(manifest.baseType);
+    // Ensure no combat fields are present at runtime
+    const keys = Object.keys(manifest);
+    const combatFields = ["hp", "maxHp", "damage", "skills", "defense", "attack", "power"];
+    for (const field of combatFields) {
+      assert.ok(!keys.includes(field), `SkinPackManifest must not contain combat field: ${field}`);
+    }
+  });
+
+  it("SkinPack should only add visual asset paths, no combat fields", () => {
+    const pack: SkinPack = {
+      id: "test-skin",
+      name: "Test Skin",
+      codename: "FALCON UNIT",
+      themeColor: "#FF0000",
+      baseType: MechType.Kinetic,
+      mechSprite: "/assets/skins/test/mech.png",
+      portraits: {
+        normal: "/assets/skins/test/portrait-normal.png",
+        angry: "/assets/skins/test/portrait-angry.png",
+        defeated: "/assets/skins/test/portrait-defeated.png",
+      },
+      thumbnail: "/assets/skins/test/thumbnail.png",
+    };
+    const keys = Object.keys(pack);
+    const combatFields = ["hp", "maxHp", "damage", "skills", "defense", "attack", "power"];
+    for (const field of combatFields) {
+      assert.ok(!keys.includes(field), `SkinPack must not contain combat field: ${field}`);
+    }
+  });
+});
+
+describe("skin separation — buildRequestBody excludes skin data", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    mock.restoreAll();
+  });
+
+  it("request body should not contain skinId or skin-related fields", () => {
+    const body = buildRequestBody("be aggressive", makeGameState());
+    const json = JSON.stringify(body);
+    // Skin fields must not appear in the request body
+    assert.ok(!json.includes("skinId"), "request body must not contain skinId");
+    assert.ok(!json.includes("skinName"), "request body must not contain skinName");
+    assert.ok(!json.includes("themeColor"), "request body must not contain themeColor");
+    assert.ok(!json.includes("mechSprite"), "request body must not contain mechSprite");
+    assert.ok(!json.includes("thumbnail"), "request body must not contain thumbnail");
+    assert.ok(!json.includes("portrait"), "request body must not contain portrait");
+  });
+
+  it("request body should only contain combat-relevant fields", () => {
+    const body = buildRequestBody("test prompt", makeGameState());
+    // Top-level keys
+    const topKeys = Object.keys(body);
+    assert.deepEqual(topKeys.sort(), ["gameState", "mechPrompt"]);
+    // gameState keys
+    const gsKeys = Object.keys(body.gameState);
+    const expected = ["combatCore", "lastMove", "opponentHP", "playerHP", "skills", "statusEffects"];
+    assert.deepEqual(gsKeys.sort(), expected);
+  });
+});
+
+describe("skin separation — buildPrompt excludes skin data", () => {
+  it("prompt output should not contain skin-related terms", () => {
+    const prompt = buildPrompt({
+      mechPrompt: "Focus fire",
+      gameState: {
+        playerHP: 80,
+        opponentHP: 60,
+        lastMove: "Railgun Salvo",
+        statusEffects: [],
+        skills: [
+          { name: "Railgun Salvo", type: "kinetic", damage: 40 },
+          { name: "Plasma Beam", type: "beam", damage: 30 },
+          { name: "EMP Pulse", type: "emp", damage: 25 },
+          { name: "Reactive Armor", type: "defense", damage: 0 },
+        ],
+        combatCore: { name: "Aggressive", prompt: "Always attack first" },
+      },
+    });
+    // Prompt should not reference skins
+    assert.ok(!prompt.toLowerCase().includes("skin"), "prompt must not mention 'skin'");
+    assert.ok(!prompt.toLowerCase().includes("cosmetic"), "prompt must not mention 'cosmetic'");
+    assert.ok(!prompt.toLowerCase().includes("appearance"), "prompt must not mention 'appearance'");
+    // Prompt should contain combat data
+    assert.ok(prompt.includes("Aggressive"), "prompt should include combat core name");
+    assert.ok(prompt.includes("Focus fire"), "prompt should include player instructions");
+    assert.ok(prompt.includes("80"), "prompt should include player HP");
+  });
+
+  it("prompt should only use combatCore, mechPrompt, and gameState", () => {
+    const prompt = buildPrompt({
+      mechPrompt: "",
+      gameState: {
+        playerHP: 100,
+        opponentHP: 100,
+        lastMove: "",
+        statusEffects: [],
+        skills: [{ name: "Test Skill", type: "kinetic", damage: 10 }],
+      },
+    });
+    // Should contain game state
+    assert.ok(prompt.includes("Your HP: 100"));
+    assert.ok(prompt.includes("Opponent HP: 100"));
+    assert.ok(prompt.includes("Test Skill"));
+    // Should not contain cosmetic references
+    assert.ok(!prompt.includes("desert-storm"));
+    assert.ok(!prompt.includes("arctic-ops"));
+    assert.ok(!prompt.includes("crimson-fury"));
+  });
+});


### PR DESCRIPTION
## Summary
- Add cosmetic-only doc comments to SkinPackManifest and SkinPack types
- Export and document buildRequestBody to enforce no-skin-in-API contract
- Document buildPrompt as combat-only (no skin data in AI prompt)
- Rename UI labels from "Skin" to "Appearance" for neutral cosmetic wording
- Add docs/SKIN_SEPARATION.md documenting the separation principle
- Add 6 unit tests verifying skin data exclusion from API and prompt

Closes #149

## Test plan
- [x] 6 new skinSeparation tests pass
- [x] Full test suite (658 tests) passes with no regressions
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)